### PR TITLE
Bump up surveysvc-api artifact version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>surveysvc-api</artifactId>
-      <version>10.49.0</version>
+      <version>10.49.2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Just updating the surveysvc-api artifact version.
This version allows 'legalbasis' to be in responses from survey service. Legalbasis is not used in this service so no further changes are required.