### PR TITLE
Send Notification/Reminder messages to ActionExporter and Notify-gateway

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,13 +37,13 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>actionsvc-api</artifactId>
-      <version>10.49.3-SNAPSHOT</version>
+      <version>10.49.3</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>casesvc-api</artifactId>
-      <version>10.49.4-SNAPSHOT</version>
+      <version>10.49.3</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>actionsvc-api</artifactId>
-      <version>10.49.0</version>
+      <version>10.49.2-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>casesvc-api</artifactId>
-      <version>10.49.3</version>
+      <version>10.49.4</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>partysvc-api</artifactId>
-      <version>10.50.2</version>
+      <version>10.50.3</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>actionsvc-api</artifactId>
-      <version>10.49.3</version>
+      <version>10.49.4</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,13 +37,13 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>actionsvc-api</artifactId>
-      <version>10.49.2-SNAPSHOT</version>
+      <version>10.49.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>casesvc-api</artifactId>
-      <version>10.49.3-SNAPSHOT</version>
+      <version>10.49.4-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>casesvc-api</artifactId>
-      <version>10.49.1</version>
+      <version>10.49.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/PartySvcClientService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/PartySvcClientService.java
@@ -19,4 +19,14 @@ public interface PartySvcClientService {
    * @return the Party we fetched!
    */
   PartyDTO getParty(String sampleUnitType, UUID partyId);
+
+  /**
+   * Call PartySvc using REST to get the Party MAY throw a RuntimeException if
+   * the call fails
+   *
+   * @param partyId the PartySvc UUID as string
+   * @param sampleUnitType type of sample unit
+   * @return the Party we fetched!
+   */
+  PartyDTO getParty(String sampleUnitType, String partyId);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
@@ -248,24 +248,18 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
     actionRequest.setSurveyName(surveyDTO.getLongName());
     actionRequest.setSurveyRef(surveyDTO.getSurveyRef());
 
-    CommsTypeClassifiers classifiers = new CommsTypeClassifiers();
-    classifiers.setLegalBasis(surveyDTO.getLegalBasis());
-    classifiers.setRegion(businessUnitAttributes.getRegion());
-    actionRequest.setCommsTypeClassifiers(classifiers);
-
-    Statuses statuses = new Statuses();
+    actionRequest.setLegalBasis(surveyDTO.getLegalBasis());
+    actionRequest.setRegion(businessUnitAttributes.getRegion());
 
     // For BRES Child party is BI, does this change the logic?
     if (childParty != null) {
-      statuses.setRespondentStatus(childParty.getStatus());
+      actionRequest.setRespondentStatus(childParty.getStatus());
     }
 
     // Do i need to set a default value for respondent status if no child party, as no respondent account created?
+    actionRequest.setEnrolmentStatus(getEnrolmentStatus(parentParty));
+    actionRequest.setCaseGroupStatus(caseDTO.getCaseGroupStatus().toString());
 
-    statuses.setEnrolmentStatus(getEnrolmentStatus(parentParty));
-    statuses.setCaseGroupStatus(caseDTO.getCaseGroupStatus().toString());
-
-    actionRequest.setStatuses(statuses);
 
     Date scheduledReturnDateTime = collectionExercise.getScheduledReturnDateTime();
     if (scheduledReturnDateTime != null) {

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
@@ -93,7 +93,10 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
       ActionRequest actionRequest = prepareActionRequest(action);
 
       if (actionRequest != null && validator.validate(actionType, actionRequest)) {
+        log.info("Sending actionInstruction to " + actionType.getHandler());
         actionInstructionPublisher.sendActionInstruction(actionType.getHandler(), actionRequest);
+      } else {
+        log.info("Not sending action");
       }
 
       // advise casesvc to create a corresponding caseevent for our action

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
@@ -43,10 +43,11 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
 
   public static final String CANCELLATION_REASON = "Action cancelled by Response Management";
   private static final String DATE_FORMAT_IN_REMINDER_EMAIL = "dd/MM/yyyy";
-  private static final String ENABLED = "ENABLED";
-  private static final String PENDING = "PENDING";
-  private static final String DISABLED = "DISABLED";
-  private static final String SUSPENDED = "SUSPENDED";
+
+  public static final String ENABLED = "ENABLED";
+  public static final String PENDING = "PENDING";
+  public static final String DISABLED = "DISABLED";
+  public static final String SUSPENDED = "SUSPENDED";
 
   @Autowired
   private CaseSvcClientService caseSvcClientService;
@@ -72,6 +73,9 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
   @Autowired
   private StateTransitionManager<ActionDTO.ActionState, ActionDTO.ActionEvent> actionSvcStateTransitionManager;
 
+  @Autowired
+  private ActionRequestValidator validator;
+
   /**
    * Deal with a single action - the transaction boundary is here.
    *
@@ -92,7 +96,8 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
       transitionAction(action, event);
 
       ActionRequest actionRequest = prepareActionRequest(action);
-      if (actionRequest != null) {
+
+      if (actionRequest != null && validator.validate(actionType, actionRequest)) {
         actionInstructionPublisher.sendActionInstruction(actionType.getHandler(), actionRequest);
       }
 
@@ -165,6 +170,7 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
       return null;
     }
   }
+
 
   /**
    * Take an action and using it, fetch further info from Case service in a

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
@@ -18,10 +18,7 @@ import uk.gov.ons.ctp.response.action.message.ActionInstructionPublisher;
 import uk.gov.ons.ctp.response.action.message.instruction.*;
 import uk.gov.ons.ctp.response.action.representation.ActionDTO;
 import uk.gov.ons.ctp.response.action.service.*;
-import uk.gov.ons.ctp.response.casesvc.representation.CaseDetailsDTO;
-import uk.gov.ons.ctp.response.casesvc.representation.CaseEventDTO;
-import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupDTO;
-import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO;
+import uk.gov.ons.ctp.response.casesvc.representation.*;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 import uk.gov.ons.ctp.response.party.representation.Association;
 import uk.gov.ons.ctp.response.party.representation.Attributes;
@@ -264,8 +261,9 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
       //BI case
       actionRequest.setRespondentStatus(childParty.getStatus());
     } else {
-      //B case, sampleUnitTypeStr is the child type.
-      actionRequest.setRespondentStatus(parseRespondentStatuses(parentParty, caseDTO.getSampleUnitType()));
+      //B case
+      String parentUnitType = caseDTO.getSampleUnitType()
+      actionRequest.setRespondentStatus(parseRespondentStatuses(parentParty, parentUnitType));
     }
 
     actionRequest.setEnrolmentStatus(getEnrolmentStatus(parentParty));
@@ -284,14 +282,17 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
   /**
    *  iterate through child parties and parse respondent statuses'
    * @param parentParty
-   * @param childUnitTypeStr
+   * @param parentUnitTypeStr
    * @return
    */
-  public String parseRespondentStatuses(PartyDTO parentParty, String childUnitTypeStr) {
+  public String parseRespondentStatuses(PartyDTO parentParty, String parentUnitTypeStr) {
 
     List<String> childPartyIds = parentParty.getAssociations().stream().map(Association::getPartyId).collect(Collectors.toList());
 
     List<String> childPartyStatuses = new ArrayList<>();
+
+    //TODO: THIS IS AWFUL!! All child samples are parent+I but must be better way
+    String childUnitTypeStr = parentUnitTypeStr + "I";
 
     for (String id : childPartyIds) {
       try {

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
@@ -284,10 +284,10 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
   /**
    *  iterate through child parties and parse respondent statuses'
    * @param parentParty
-   * @param sampleUnitTypeStr
+   * @param childUnitTypeStr
    * @return
    */
-  private String parseRespondentStatuses(PartyDTO parentParty, String sampleUnitTypeStr) {
+  public String parseRespondentStatuses(PartyDTO parentParty, String childUnitTypeStr) {
 
     List<String> childPartyIds = parentParty.getAssociations().stream().map(Association::getPartyId).collect(Collectors.toList());
 
@@ -295,7 +295,7 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
 
     for (String id : childPartyIds) {
       try {
-        PartyDTO childParty = partySvcClientService.getParty(sampleUnitTypeStr, id);
+        PartyDTO childParty = partySvcClientService.getParty(childUnitTypeStr, id);
         childPartyStatuses.add(childParty.getStatus());
       } catch (RuntimeException e) {
         log.info("Unable to get party with id, {}", id);

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
@@ -44,8 +44,6 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
 
   public static final String ENABLED = "ENABLED";
   public static final String PENDING = "PENDING";
-  public static final String DISABLED = "DISABLED";
-  public static final String SUSPENDED = "SUSPENDED";
   public static final String ACTIVE = "ACTIVE";
   public static final String CREATED = "CREATED";
 
@@ -326,16 +324,16 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
         enrolmentStatuses.add(enrolment.getEnrolmentStatus());
       }
     }
+    String enrolmentStatus = null;
+
     if (enrolmentStatuses.contains(ENABLED)) {
-      return ENABLED;
+      enrolmentStatus = ENABLED;
     }
     if (enrolmentStatuses.contains(PENDING)) {
-      return PENDING;
+      enrolmentStatus = PENDING;
     }
-    if (enrolmentStatuses.contains(SUSPENDED)) {
-      return SUSPENDED;
-    }
-    return DISABLED;
+
+    return enrolmentStatus;
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
@@ -265,7 +265,7 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
       actionClassifiers.getEnrolmentStatuses().addAll(enrolmentStatuses);
     }
 
-    actionClassifiers.setResponseStatus(action.getState().toString());
+    actionClassifiers.setResponseStatus(caseDTO.getResponseState().toString());
     actionRequest.setClassifiers(actionClassifiers);
 
     Date scheduledReturnDateTime = collectionExercise.getScheduledReturnDateTime();

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
@@ -303,13 +303,15 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
 
     String respondentStatus = null;
 
+    if (childPartyStatuses.contains(CREATED)) {
+      respondentStatus =  CREATED;
+    }
+
     if (childPartyStatuses.contains(ACTIVE)) {
       respondentStatus = ACTIVE;
     }
 
-    if (childPartyStatuses.contains(CREATED)) {
-      respondentStatus = CREATED;
-    }
+
     return respondentStatus;
   }
   /**
@@ -319,18 +321,24 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
    */
   public String getEnrolmentStatus(final PartyDTO parentParty) {
     List<String> enrolmentStatuses = new ArrayList<>();
-    for (Association association : parentParty.getAssociations()) {
-      for (Enrolment enrolment : association.getEnrolments()) {
-        enrolmentStatuses.add(enrolment.getEnrolmentStatus());
+
+    List<Association> associations = parentParty.getAssociations();
+    if(associations != null) {
+      for (Association association : associations) {
+          for (Enrolment enrolment : association.getEnrolments()) {
+            enrolmentStatuses.add(enrolment.getEnrolmentStatus());
+        }
       }
     }
+
     String enrolmentStatus = null;
+
+    if (enrolmentStatuses.contains(PENDING)) {
+      enrolmentStatus = PENDING;
+    }
 
     if (enrolmentStatuses.contains(ENABLED)) {
       enrolmentStatus = ENABLED;
-    }
-    if (enrolmentStatuses.contains(PENDING)) {
-      enrolmentStatus = PENDING;
     }
 
     return enrolmentStatus;

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
@@ -284,7 +284,6 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
         enrolmentStatuses.add(enrolment.getEnrolmentStatus());
       }
     }
-    //TODO: There has got to be a better way to do this??
     if (enrolmentStatuses.contains(ENABLED)) {
       return ENABLED;
     }

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
@@ -257,11 +257,15 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
 
     // For BRES Child party is BI, does this change the logic?
     if (childParty != null) {
-      statuses.setCaseGroupStatus(childParty.getStatus());
-      statuses.setEnrolmentStatus(getEnrolmentStatus(childParty));
+      statuses.setRespondentStatus(childParty.getStatus());
     }
 
+    // Do i need to set a default value for respondent status if no child party, as no respondent account created?
+
+    statuses.setEnrolmentStatus(getEnrolmentStatus(parentParty));
     statuses.setCaseGroupStatus(caseDTO.getCaseGroupStatus().toString());
+
+    actionRequest.setStatuses(statuses);
 
     Date scheduledReturnDateTime = collectionExercise.getScheduledReturnDateTime();
     if (scheduledReturnDateTime != null) {
@@ -274,12 +278,12 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
 
   /**
    * enrolment status for the case based off the enrolled parties
-   * @param childParty
+   * @param parentParty
    * @return enrolment status
    */
-  public String getEnrolmentStatus(final PartyDTO childParty) {
+  public String getEnrolmentStatus(final PartyDTO parentParty) {
     List<String> enrolmentStatuses = new ArrayList<>();
-    for (Association association : childParty.getAssociations()) {
+    for (Association association : parentParty.getAssociations()) {
       for (Enrolment enrolment : association.getEnrolments()) {
         enrolmentStatuses.add(enrolment.getEnrolmentStatus());
       }

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
@@ -263,7 +263,7 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
       // B case with BI registered without a fully validated email
       // It needs the contact details of the non validated respondent sent to the business in the print file
       if (CREATED.equals(actionRequest.getRespondentStatus())) {
-        actionRequest.setIac(null); //Don't want to send this to the business
+        actionRequest.setIac(""); //Don't want to send this to the business, breaks if null
 
         PartyDTO createdStatusChildParty = childPartyMapByStatus.get(CREATED);
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
@@ -29,10 +29,7 @@ import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
-import java.util.ArrayList;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -293,12 +290,12 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
     String childUnitTypeStr = parentUnitTypeStr + "I";
 
     for (String id : childPartyIds) {
-      try {
         PartyDTO childParty = partySvcClientService.getParty(childUnitTypeStr, id);
-        childPartyStatuses.add(childParty.getStatus());
-      } catch (RuntimeException e) {
-        log.info("Unable to get party with id, {}", id);
-      }
+        if (childParty != null) {
+          childPartyStatuses.add(childParty.getStatus());
+        } else {
+          log.info("Unable to get party with id, {}", id);
+        }
     }
 
     String respondentStatus = null;
@@ -323,7 +320,7 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
     List<String> enrolmentStatuses = new ArrayList<>();
 
     List<Association> associations = parentParty.getAssociations();
-    if(associations != null) {
+    if (associations != null) {
       for (Association association : associations) {
           for (Enrolment enrolment : association.getEnrolments()) {
             enrolmentStatuses.add(enrolment.getEnrolmentStatus());
@@ -349,21 +346,11 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
    * @param businessUnitAttributes
    * @return concatenated trading styles
    */
-  private String generateTradingStyle(final Attributes businessUnitAttributes) {
-    String tradStyle1 = businessUnitAttributes.getTradstyle1();
-    String tradStyle2 = businessUnitAttributes.getTradstyle2();
-    String tradStyle3 = businessUnitAttributes.getTradstyle3();
-    StringBuffer tradStyle = new StringBuffer();
-    if (!StringUtils.isEmpty(tradStyle1)) {
-      tradStyle.append(String.format("%s ", tradStyle1));
-    }
-    if (!StringUtils.isEmpty(tradStyle2)) {
-      tradStyle.append(String.format("%s ", tradStyle2));
-    }
-    if (!StringUtils.isEmpty(tradStyle3)) {
-      tradStyle.append(tradStyle3);
-    }
-    return tradStyle.toString().trim();
+  public String generateTradingStyle(final Attributes businessUnitAttributes) {
+    List<String> tradeStyles = Arrays.asList(businessUnitAttributes.getTradstyle1(),
+            businessUnitAttributes.getTradstyle2(), businessUnitAttributes.getTradstyle3());
+    return tradeStyles.stream().filter(Objects::nonNull)
+            .collect(Collectors.joining(" "));
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
@@ -1,7 +1,6 @@
 package uk.gov.ons.ctp.response.action.service.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.type.AssociationType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -33,7 +32,10 @@ import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.ArrayList;
 
 @Slf4j
 @Service
@@ -270,6 +272,11 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
     return actionRequest;
   }
 
+  /**
+   * enrolment status for the case based off the enrolled parties
+   * @param childParty
+   * @return enrolment status
+   */
   private String getEnrolmentStatus(final PartyDTO childParty) {
     List<String> enrolmentStatuses = new ArrayList<>();
     for (Association association : childParty.getAssociations()) {
@@ -278,13 +285,13 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
       }
     }
     //TODO: There has got to be a better way to do this??
-    if(enrolmentStatuses.contains(ENABLED)) {
+    if (enrolmentStatuses.contains(ENABLED)) {
       return ENABLED;
     }
-    if(enrolmentStatuses.contains(PENDING)) {
+    if (enrolmentStatuses.contains(PENDING)) {
       return PENDING;
     }
-    if(enrolmentStatuses.contains(SUSPENDED)) {
+    if (enrolmentStatuses.contains(SUSPENDED)) {
       return SUSPENDED;
     }
     return DISABLED;

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
@@ -277,7 +277,7 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
    * @param childParty
    * @return enrolment status
    */
-  private String getEnrolmentStatus(final PartyDTO childParty) {
+  public String getEnrolmentStatus(final PartyDTO childParty) {
     List<String> enrolmentStatuses = new ArrayList<>();
     for (Association association : childParty.getAssociations()) {
       for (Enrolment enrolment : association.getEnrolments()) {

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
@@ -262,7 +262,7 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
       actionRequest.setRespondentStatus(childParty.getStatus());
     } else {
       //B case
-      String parentUnitType = caseDTO.getSampleUnitType()
+      String parentUnitType = caseDTO.getSampleUnitType();
       actionRequest.setRespondentStatus(parseRespondentStatuses(parentParty, parentUnitType));
     }
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
@@ -213,7 +213,7 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
     CaseGroupDTO caseGroupDTO = caseDTO.getCaseGroup();
     UUID collectionExerciseId = caseGroupDTO.getCollectionExerciseId();
     CollectionExerciseDTO collectionExercise = collectionExerciseClientService.getCollectionExercise(
-        collectionExerciseId);
+            collectionExerciseId);
     actionRequest.setExerciseRef(collectionExercise.getExerciseRef());
 
     ActionContact actionContact = new ActionContact();
@@ -251,12 +251,13 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
     actionRequest.setLegalBasis(surveyDTO.getLegalBasis());
     actionRequest.setRegion(businessUnitAttributes.getRegion());
 
-    // For BRES Child party is BI, does this change the logic?
+    // If it a B party then the respondent status is that of the child BI party
     if (childParty != null) {
       actionRequest.setRespondentStatus(childParty.getStatus());
+    } else {
+      actionRequest.setRespondentStatus(parentParty.getStatus());
     }
 
-    // Do i need to set a default value for respondent status if no child party, as no respondent account created?
     actionRequest.setEnrolmentStatus(getEnrolmentStatus(parentParty));
     actionRequest.setCaseGroupStatus(caseDTO.getCaseGroupStatus().toString());
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidator.java
@@ -60,11 +60,11 @@ public class ActionRequestValidator {
     }
 
     private boolean isLetter(final String handler) {
-        return handler.equals(ACTIONEXPORTER);
+        return handler.equalsIgnoreCase(ACTIONEXPORTER);
     }
 
     private boolean isEmail(final String handler) {
-        return handler.equals(NOTIFYGATEWAY);
+        return handler.equalsIgnoreCase(NOTIFYGATEWAY);
     }
 
     private boolean isNotificationLetter(final ActionType actionType) {
@@ -85,27 +85,27 @@ public class ActionRequestValidator {
     }
 
     private boolean caseInProgress(final ActionRequest actionRequest) {
-        return actionRequest.getCaseGroupStatus().equals(CaseGroupStatus.INPROGRESS.toString());
+        return actionRequest.getCaseGroupStatus().equalsIgnoreCase(CaseGroupStatus.INPROGRESS.toString());
     }
 
     private boolean caseNotStarted(final ActionRequest actionRequest) {
-        return actionRequest.getCaseGroupStatus().equals(CaseGroupStatus.NOTSTARTED.toString());
+        return actionRequest.getCaseGroupStatus().equalsIgnoreCase(CaseGroupStatus.NOTSTARTED.toString());
     }
 
     private boolean enrolmentPending(final ActionRequest actionRequest) {
-        return actionRequest.getEnrolmentStatus().equals(ActionProcessingServiceImpl.PENDING);
+        return actionRequest.getEnrolmentStatus().equalsIgnoreCase(ActionProcessingServiceImpl.PENDING);
     }
 
     private boolean enrolmentEnabled(final ActionRequest actionRequest) {
-        return actionRequest.getEnrolmentStatus().equals(ActionProcessingServiceImpl.ENABLED);
+        return actionRequest.getEnrolmentStatus().equalsIgnoreCase(ActionProcessingServiceImpl.ENABLED);
     }
 
     private boolean hasActiveRespondent(final ActionRequest actionRequest) {
-        return actionRequest.getRespondentStatus().equals(RESPONDENTACTIVE);
+        return actionRequest.getRespondentStatus().equalsIgnoreCase(RESPONDENTACTIVE);
     }
 
     private boolean hasCreatedRespondent(final ActionRequest actionRequest) {
-        return actionRequest.getRespondentStatus().equals(RESPONDENTCREATED);
+        return actionRequest.getRespondentStatus().equalsIgnoreCase(RESPONDENTCREATED);
     }
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidator.java
@@ -1,0 +1,93 @@
+package uk.gov.ons.ctp.response.action.service.impl;
+
+import org.springframework.stereotype.Service;
+import uk.gov.ons.ctp.response.action.domain.model.ActionType;
+import uk.gov.ons.ctp.response.action.message.instruction.ActionRequest;
+import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
+
+@Service
+public class ActionRequestValidator {
+
+    public static final String RESPONDENTCREATED = "CREATED";
+    public static final String RESPONDENTACTIVE= "ACTIVE";
+
+    public boolean validate(ActionType actionType, ActionRequest actionRequest) {
+        // Completed no action required
+        if(actionRequest.getCaseGroupStatus().equals(CaseGroupStatus.COMPLETE.toString())) {
+            return false;
+        }
+
+        if (hasActiveRespondent(actionRequest) && enrolmentEnabled(actionRequest)) {
+            return validateEmail(actionType, actionRequest);
+        }
+
+        if (hasCreatedRespondent(actionRequest)) {
+            return validateLetter(actionType, actionRequest);
+        }
+        return false;
+    }
+
+
+    private boolean validateEmail(final ActionType actionType, final ActionRequest actionRequest) {
+        if (isNotificationEmail(actionType)) {
+            return true;
+        }
+        if (isReminderEmail(actionType) && (caseInProgress(actionRequest) || caseNotStarted(actionRequest))) {
+            return true;
+        }
+        return false;
+    }
+
+    private boolean validateLetter(final ActionType actionType, final ActionRequest actionRequest) {
+        if(isNotificationLetter(actionType) && enrolmentPending(actionRequest)) {
+            return true;
+        }
+        if (isReminderLetter(actionType) && (enrolmentPending(actionRequest) || enrolmentEnabled(actionRequest))) {
+            return true;
+        }
+        return false;
+
+    }
+
+    private boolean isNotificationLetter(final ActionType actionType) {
+        return actionType.getActionTypePK().equals(1);
+    }
+
+    private boolean isReminderLetter(final ActionType actionType) {
+        return actionType.getActionTypePK().equals(2);
+    }
+
+    private boolean isReminderEmail(final ActionType actionType) {
+        return actionType.getActionTypePK().equals(3);
+    }
+
+    private boolean isNotificationEmail(final ActionType actionType) {
+        //TODO: Currently not available in system but will be added
+        return actionType.getActionTypePK().equals(4);
+    }
+
+    private boolean caseInProgress(final ActionRequest actionRequest) {
+        return actionRequest.getCaseGroupStatus().equals(CaseGroupStatus.INPROGRESS.toString());
+    }
+
+    private boolean caseNotStarted(final ActionRequest actionRequest) {
+        return actionRequest.getCaseGroupStatus().equals(CaseGroupStatus.NOTSTARTED.toString());
+    }
+
+    private boolean enrolmentPending(final ActionRequest actionRequest) {
+        return actionRequest.getEnrolmentStatus().equals(ActionProcessingServiceImpl.PENDING);
+    }
+
+    private boolean enrolmentEnabled(final ActionRequest actionRequest) {
+        return actionRequest.getEnrolmentStatus().equals(ActionProcessingServiceImpl.ENABLED);
+    }
+
+    private boolean hasActiveRespondent(final ActionRequest actionRequest) {
+        return actionRequest.getRespondentStatus().equals(RESPONDENTACTIVE);
+    }
+
+    private boolean hasCreatedRespondent(final ActionRequest actionRequest) {
+        return actionRequest.getRespondentStatus().equals(RESPONDENTCREATED);
+    }
+
+}

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidator.java
@@ -1,10 +1,12 @@
 package uk.gov.ons.ctp.response.action.service.impl;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.response.action.domain.model.ActionType;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionRequest;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
 
+@Slf4j
 @Service
 public class ActionRequestValidator {
 
@@ -35,6 +37,9 @@ public class ActionRequestValidator {
         if (isLetter(handler)) {
             return validateLetter(actionRequest);
         }
+
+        log.info("Invalid Action Request: "+ actionRequest.toString());
+
         return false;
     }
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidator.java
@@ -38,7 +38,9 @@ public class ActionRequestValidator {
             return validateLetter(actionRequest);
         }
 
-        log.info("Invalid Action Request: "+ actionRequest.toString());
+        log.info("Invalid action request: handler = {} : respondentStatus {} :  enrolmentStatus {} : actionTypePK {}",
+                handler, actionRequest.getCaseGroupStatus(), actionRequest.getEnrolmentStatus(),
+                actionType.getActionTypePK());
 
         return false;
     }

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidator.java
@@ -68,20 +68,20 @@ public class ActionRequestValidator {
     }
 
     private boolean isNotificationLetter(final ActionType actionType) {
-        return actionType.getActionTypePK().equals(1);
+        return actionType.getActionTypePK() != null && actionType.getActionTypePK().equals(1);
     }
 
     private boolean isReminderLetter(final ActionType actionType) {
-        return actionType.getActionTypePK().equals(2);
+        return actionType.getActionTypePK() != null && actionType.getActionTypePK().equals(2);
     }
 
     private boolean isReminderEmail(final ActionType actionType) {
-        return actionType.getActionTypePK().equals(3);
+        return actionType.getActionTypePK() != null && actionType.getActionTypePK().equals(3);
     }
 
     private boolean isNotificationEmail(final ActionType actionType) {
         //TODO: Currently not available in system but will be added
-        return actionType.getActionTypePK().equals(4);
+        return actionType.getActionTypePK() != null && actionType.getActionTypePK().equals(4);
     }
 
     private boolean caseInProgress(final ActionRequest actionRequest) {
@@ -93,19 +93,19 @@ public class ActionRequestValidator {
     }
 
     private boolean enrolmentPending(final ActionRequest actionRequest) {
-        return actionRequest.getEnrolmentStatus().equalsIgnoreCase(ActionProcessingServiceImpl.PENDING);
+        return actionRequest.getEnrolmentStatus() != null && actionRequest.getEnrolmentStatus().equalsIgnoreCase(ActionProcessingServiceImpl.PENDING);
     }
 
     private boolean enrolmentEnabled(final ActionRequest actionRequest) {
-        return actionRequest.getEnrolmentStatus().equalsIgnoreCase(ActionProcessingServiceImpl.ENABLED);
+        return actionRequest.getEnrolmentStatus() != null && actionRequest.getEnrolmentStatus().equalsIgnoreCase(ActionProcessingServiceImpl.ENABLED);
     }
 
     private boolean hasActiveRespondent(final ActionRequest actionRequest) {
-        return actionRequest.getRespondentStatus().equalsIgnoreCase(RESPONDENTACTIVE);
+        return actionRequest.getRespondentStatus() != null && actionRequest.getRespondentStatus().equalsIgnoreCase(RESPONDENTACTIVE);
     }
 
     private boolean hasCreatedRespondent(final ActionRequest actionRequest) {
-        return actionRequest.getRespondentStatus().equalsIgnoreCase(RESPONDENTCREATED);
+        return actionRequest.getRespondentStatus() != null && actionRequest.getRespondentStatus().equalsIgnoreCase(RESPONDENTCREATED);
     }
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidator.java
@@ -10,18 +10,29 @@ public class ActionRequestValidator {
 
     public static final String RESPONDENTCREATED = "CREATED";
     public static final String RESPONDENTACTIVE= "ACTIVE";
+    public static final String NOTIFYGATEWAY = "NOTIFY";
+    public static final String ACTIONEXPORTER = "PRINTER";
 
-    public boolean validate(ActionType actionType, ActionRequest actionRequest) {
+    /**
+     * Validates whether the ActionRequest should be sent to a handler service.
+     * Contains the business logic for deciding whether the recipient is to receive an email or letter,
+     * dependent on the status of their account and the response.
+     * @param actionType
+     * @param actionRequest
+     * @return isValid
+     */
+    public boolean validate(final ActionType actionType, final ActionRequest actionRequest) {
+        String handler = actionType.getHandler();
         // Completed no action required
-        if(actionRequest.getCaseGroupStatus().equals(CaseGroupStatus.COMPLETE.toString())) {
+        if (actionRequest.getCaseGroupStatus().equals(CaseGroupStatus.COMPLETE.toString())) {
             return false;
         }
 
-        if (hasActiveRespondent(actionRequest) && enrolmentEnabled(actionRequest)) {
+        if (isEmail(handler) && hasActiveRespondent(actionRequest) && enrolmentEnabled(actionRequest)) {
             return validateEmail(actionType, actionRequest);
         }
 
-        if (hasCreatedRespondent(actionRequest)) {
+        if (isLetter(handler) && hasCreatedRespondent(actionRequest)) {
             return validateLetter(actionType, actionRequest);
         }
         return false;
@@ -46,7 +57,14 @@ public class ActionRequestValidator {
             return true;
         }
         return false;
+    }
 
+    private boolean isLetter(final String handler) {
+        return handler.equals(ACTIONEXPORTER);
+    }
+
+    private boolean isEmail(final String handler) {
+        return handler.equals(NOTIFYGATEWAY);
     }
 
     private boolean isNotificationLetter(final ActionType actionType) {

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/PartySvcClientServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/PartySvcClientServiceImpl.java
@@ -51,12 +51,25 @@ public class PartySvcClientServiceImpl implements PartySvcClientService {
     UriComponents uriComponents = restUtility.createUriComponents(
         appConfig.getPartySvc().getPartyBySampleUnitTypeAndIdPath(), null, sampleUnitType, partyId);
     
+    return makePartyServiceRequest(uriComponents);
+  }
+
+  @Override
+  public PartyDTO getParty(final String sampleUnitType, final String partyId) {
+    log.debug("entering party with sampleUnitType {} - partyId {}", sampleUnitType, partyId);
+    UriComponents uriComponents = restUtility.createUriComponents(
+            appConfig.getPartySvc().getPartyBySampleUnitTypeAndIdPath(), null, sampleUnitType, partyId);
+
+    return makePartyServiceRequest(uriComponents);
+  }
+
+  private PartyDTO makePartyServiceRequest(UriComponents uriComponents) {
     HttpEntity<?> httpEntity = restUtility.createHttpEntity(null);
-    
+
     ResponseEntity<String> responseEntity = restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity,
-        String.class);
+            String.class);
     log.debug("responseEntity is {}", responseEntity);
-    
+
     PartyDTO result = null;
     if (responseEntity != null && responseEntity.getStatusCode().is2xxSuccessful()) {
       String responseBody = responseEntity.getBody();

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.java
@@ -213,6 +213,8 @@ public class ActionProcessingServiceImplTest {
 
     when(caseSvcClientService.createNewCaseEvent(any(Action.class), any(CategoryDTO.CategoryName.class))).
         thenThrow(new RuntimeException(REST_ERROR_MSG));
+
+    when(actionSvcStateTransitionManager.transition(any(ActionDTO.ActionState.class), any(ActionDTO.ActionEvent.class))).thenReturn(ActionDTO.ActionState.PENDING);
     // End of section to mock responses
 
     try {
@@ -262,6 +264,8 @@ public class ActionProcessingServiceImplTest {
         thenReturn(collectionExerciseDTOs.get(0));
 
     when(surveySvcClientService.requestDetailsForSurvey(CENSUS)).thenReturn(surveyDTOs.get(0));
+
+    when(actionSvcStateTransitionManager.transition(any(ActionDTO.ActionState.class), any(ActionDTO.ActionEvent.class))).thenReturn(ActionDTO.ActionState.PENDING);
     // End of section to mock responses
 
     // Start of section to run the test
@@ -350,6 +354,7 @@ public class ActionProcessingServiceImplTest {
         thenReturn(collectionExerciseDTOs.get(0));
 
     when(surveySvcClientService.requestDetailsForSurvey(CENSUS)).thenReturn(surveyDTOs.get(0));
+    when(actionSvcStateTransitionManager.transition(any(ActionDTO.ActionState.class), any(ActionDTO.ActionEvent.class))).thenReturn(ActionDTO.ActionState.PENDING);
     // End of section to mock responses
 
     // Start of section to run the test

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ons.ctp.response.action.service.impl;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.*;
@@ -558,29 +557,41 @@ public class ActionProcessingServiceImplTest {
   }
 
   @Test
-  @Ignore
   public void testParseRespondentStatusesActive() {
-    when(partySvcClientService.getParty("BI",partyDTOs.get(B_PARTY).getAssociations().get(0).getPartyId())).thenReturn(partyDTOs.get(ACTIVE_BI));
-    when(partySvcClientService.getParty("BI",partyDTOs.get(B_PARTY).getAssociations().get(1).getPartyId())).thenReturn(partyDTOs.get(CREATED_BI));
-    String respondentStatus = actionProcessingService.parseRespondentStatuses(partyDTOs.get(B_PARTY), "BI");
+    //Have to set it this way as the api class uses @JSONIGNORE on status, this allows for a single DTO for BI and B
+    // cases but will ignore when serializing from json, which is how the loadClassFixtures helpers populate test data
+    PartyDTO respondentActiveBI = partyDTOs.get(ACTIVE_BI);
+    respondentActiveBI.setStatus("ACTIVE");
+    PartyDTO respondentCreatedBI = partyDTOs.get(CREATED_BI);
+    respondentCreatedBI.setStatus("CREATED");
+
+    when(partySvcClientService.getParty("BI", partyDTOs.get(B_PARTY).getAssociations().get(0).getPartyId())).thenReturn(respondentActiveBI);
+    when(partySvcClientService.getParty("BI", partyDTOs.get(B_PARTY).getAssociations().get(1).getPartyId())).thenReturn(respondentCreatedBI);
+    String respondentStatus = actionProcessingService.parseRespondentStatuses(partyDTOs.get(B_PARTY), "B");
 
     assertEquals(actionProcessingService.ACTIVE, respondentStatus);
   }
 
-  @Ignore
   @Test
   public void testParseRespondentStatusesCreated() {
-    when(partySvcClientService.getParty("BI",partyDTOs.get(B_PARTY).getAssociations().get(0).getPartyId())).thenReturn(partyDTOs.get(SUSPENDED_BI));
-    when(partySvcClientService.getParty("BI",partyDTOs.get(B_PARTY).getAssociations().get(1).getPartyId())).thenReturn(partyDTOs.get(CREATED_BI));
-    String respondentStatus = actionProcessingService.parseRespondentStatuses(partyDTOs.get(B_PARTY), "BI");
+    //Have to set it this way as the api class uses @JSONIGNORE on status, this allows for a single DTO for BI and B
+    // cases but will ignore when serializing from json, which is how the loadClassFixtures helpers populate test data
+    PartyDTO respondentSuspendedBI = partyDTOs.get(SUSPENDED_BI);
+    respondentSuspendedBI.setStatus("SUSPENDED");
+    PartyDTO respondentCreatedBI = partyDTOs.get(CREATED_BI);
+    respondentCreatedBI.setStatus("CREATED");
+
+    when(partySvcClientService.getParty("BI", partyDTOs.get(B_PARTY).getAssociations().get(0).getPartyId())).thenReturn(respondentSuspendedBI);
+    when(partySvcClientService.getParty("BI", partyDTOs.get(B_PARTY).getAssociations().get(1).getPartyId())).thenReturn(respondentCreatedBI);
+
+    String respondentStatus = actionProcessingService.parseRespondentStatuses(partyDTOs.get(B_PARTY), "B");
 
     assertEquals(actionProcessingService.CREATED, respondentStatus);
   }
 
-  @Ignore
   @Test
   public void testParseRespondentStatusesEmpty() {
-    String respondentStatus = actionProcessingService.parseRespondentStatuses(partyDTOs.get(NO_ASSOCIATIONS_BI), "BI");
+    String respondentStatus = actionProcessingService.parseRespondentStatuses(partyDTOs.get(NO_ASSOCIATIONS_BI), "B");
 
     assertEquals(null, respondentStatus);
   }
@@ -600,6 +611,13 @@ public class ActionProcessingServiceImplTest {
   @Test
   public void testGetEnrolmentStatusDefault() {
     PartyDTO partyDTO = partyDTOs.get(2);
+    assertEquals(null, actionProcessingService.getEnrolmentStatus(partyDTO));
+  }
+
+  @Test
+  public void testGetEnrolmentStatusNoEnrolments() {
+    PartyDTO partyDTO = partyDTOs.get(2);
+    partyDTO.setAssociations(null);
     assertEquals(null, actionProcessingService.getEnrolmentStatus(partyDTO));
   }
 

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.java
@@ -494,4 +494,28 @@ public class ActionProcessingServiceImplTest {
     assertTrue(publishedActionCancel.isResponseRequired());
     assertEquals(CANCELLATION_REASON, publishedActionCancel.getReason());
   }
+
+  @Test
+  public void testGetEnrolmentStatusEnabled () {
+    PartyDTO partyDTO = partyDTOs.get(0);
+    assertEquals("ENABLED", actionProcessingService.getEnrolmentStatus(partyDTO));
+  }
+
+  @Test
+  public void getTestGetEnrolmentStatusPending() {
+    PartyDTO partyDTO = partyDTOs.get(1);
+    assertEquals("PENDING", actionProcessingService.getEnrolmentStatus(partyDTO));
+  }
+
+  @Test
+  public void getTestGetEnrolmentStatusSuspended() {
+    PartyDTO partyDTO = partyDTOs.get(2);
+    assertEquals("SUSPENDED", actionProcessingService.getEnrolmentStatus(partyDTO));
+  }
+
+  @Test
+  public void getTestGetEnrolmentStatusDisabled() {
+    PartyDTO partyDTO = partyDTOs.get(3);
+    assertEquals("DISABLED", actionProcessingService.getEnrolmentStatus(partyDTO));
+  }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.java
@@ -558,6 +558,7 @@ public class ActionProcessingServiceImplTest {
   }
 
   @Test
+  @Ignore
   public void testParseRespondentStatusesActive() {
     when(partySvcClientService.getParty("BI",partyDTOs.get(B_PARTY).getAssociations().get(0).getPartyId())).thenReturn(partyDTOs.get(ACTIVE_BI));
     when(partySvcClientService.getParty("BI",partyDTOs.get(B_PARTY).getAssociations().get(1).getPartyId())).thenReturn(partyDTOs.get(CREATED_BI));

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.java
@@ -598,14 +598,9 @@ public class ActionProcessingServiceImplTest {
   }
 
   @Test
-  public void testGetEnrolmentStatusSuspended() {
+  public void testGetEnrolmentStatusDefault() {
     PartyDTO partyDTO = partyDTOs.get(2);
-    assertEquals(actionProcessingService.SUSPENDED, actionProcessingService.getEnrolmentStatus(partyDTO));
+    assertEquals(null, actionProcessingService.getEnrolmentStatus(partyDTO));
   }
 
-  @Test
-  public void testGetEnrolmentStatusDisabled() {
-    PartyDTO partyDTO = partyDTOs.get(3);
-    assertEquals(actionProcessingService.DISABLED, actionProcessingService.getEnrolmentStatus(partyDTO));
-  }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.java
@@ -535,12 +535,8 @@ public class ActionProcessingServiceImplTest {
 
   @Test
   public void testParseRespondentStatusesActive() {
-    //Have to set it this way as the api class uses @JSONIGNORE on status, this allows for a single DTO for BI and B
-    // cases but will ignore when serializing from json, which is how the loadClassFixtures helpers populate test data
     PartyDTO respondentActiveBI = partyDTOs.get(ACTIVE_BI);
-    respondentActiveBI.setStatus("ACTIVE");
     PartyDTO respondentCreatedBI = partyDTOs.get(CREATED_BI);
-    respondentCreatedBI.setStatus("CREATED");
 
     when(partySvcClientService.getParty("BI", partyDTOs.get(B_PARTY).getAssociations().get(0).getPartyId())).thenReturn(respondentActiveBI);
     when(partySvcClientService.getParty("BI", partyDTOs.get(B_PARTY).getAssociations().get(1).getPartyId())).thenReturn(respondentCreatedBI);
@@ -551,12 +547,8 @@ public class ActionProcessingServiceImplTest {
 
   @Test
   public void testParseRespondentStatusesCreated() {
-    //Have to set it this way as the api class uses @JSONIGNORE on status, this allows for a single DTO for BI and B
-    // cases but will ignore when serializing from json, which is how the loadClassFixtures helpers populate test data
     PartyDTO respondentSuspendedBI = partyDTOs.get(SUSPENDED_BI);
-    respondentSuspendedBI.setStatus("SUSPENDED");
     PartyDTO respondentCreatedBI = partyDTOs.get(CREATED_BI);
-    respondentCreatedBI.setStatus("CREATED");
 
     when(partySvcClientService.getParty("BI", partyDTOs.get(B_PARTY).getAssociations().get(0).getPartyId())).thenReturn(respondentSuspendedBI);
     when(partySvcClientService.getParty("BI", partyDTOs.get(B_PARTY).getAssociations().get(1).getPartyId())).thenReturn(respondentCreatedBI);

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.action.service.impl;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.*;
@@ -53,6 +54,12 @@ public class ActionProcessingServiceImplTest {
   private static final String REST_ERROR_MSG = "REST call is KO.";
   private static final String SAMPLE_UNIT_TYPE_H = "H";
   private static final String SAMPLE_UNIT_TYPE_HI = "HI";
+  private static final Integer B_PARTY = 4;
+  private static final Integer ACTIVE_BI = 5;
+  private static final Integer SUSPENDED_BI = 6;
+  private static final Integer CREATED_BI = 7;
+  private static final Integer NO_ASSOCIATIONS_BI = 8;
+
 
   private static final UUID ACTION_ID = UUID.fromString("7fac359e-645b-487e-bb02-70536eae51d1");
   private static final UUID CASE_ID = UUID.fromString("7fac359e-645b-487e-bb02-70536eae51d4");
@@ -551,26 +558,53 @@ public class ActionProcessingServiceImplTest {
   }
 
   @Test
+  public void testParseRespondentStatusesActive() {
+    when(partySvcClientService.getParty("BI",partyDTOs.get(B_PARTY).getAssociations().get(0).getPartyId())).thenReturn(partyDTOs.get(ACTIVE_BI));
+    when(partySvcClientService.getParty("BI",partyDTOs.get(B_PARTY).getAssociations().get(1).getPartyId())).thenReturn(partyDTOs.get(CREATED_BI));
+    String respondentStatus = actionProcessingService.parseRespondentStatuses(partyDTOs.get(B_PARTY), "BI");
+
+    assertEquals(actionProcessingService.ACTIVE, respondentStatus);
+  }
+
+  @Ignore
+  @Test
+  public void testParseRespondentStatusesCreated() {
+    when(partySvcClientService.getParty("BI",partyDTOs.get(B_PARTY).getAssociations().get(0).getPartyId())).thenReturn(partyDTOs.get(SUSPENDED_BI));
+    when(partySvcClientService.getParty("BI",partyDTOs.get(B_PARTY).getAssociations().get(1).getPartyId())).thenReturn(partyDTOs.get(CREATED_BI));
+    String respondentStatus = actionProcessingService.parseRespondentStatuses(partyDTOs.get(B_PARTY), "BI");
+
+    assertEquals(actionProcessingService.CREATED, respondentStatus);
+  }
+
+  @Ignore
+  @Test
+  public void testParseRespondentStatusesEmpty() {
+    String respondentStatus = actionProcessingService.parseRespondentStatuses(partyDTOs.get(NO_ASSOCIATIONS_BI), "BI");
+
+    assertEquals(null, respondentStatus);
+  }
+
+  @Test
   public void testGetEnrolmentStatusEnabled () {
     PartyDTO partyDTO = partyDTOs.get(0);
-    assertEquals("ENABLED", actionProcessingService.getEnrolmentStatus(partyDTO));
+    assertEquals(actionProcessingService.ENABLED, actionProcessingService.getEnrolmentStatus(partyDTO));
   }
 
   @Test
   public void testGetEnrolmentStatusPending() {
     PartyDTO partyDTO = partyDTOs.get(1);
-    assertEquals("PENDING", actionProcessingService.getEnrolmentStatus(partyDTO));
+    assertEquals(actionProcessingService.PENDING, actionProcessingService.getEnrolmentStatus(partyDTO));
   }
 
   @Test
   public void testGetEnrolmentStatusSuspended() {
     PartyDTO partyDTO = partyDTOs.get(2);
-    assertEquals("SUSPENDED", actionProcessingService.getEnrolmentStatus(partyDTO));
+    assertEquals(actionProcessingService.SUSPENDED, actionProcessingService.getEnrolmentStatus(partyDTO));
   }
 
   @Test
   public void testGetEnrolmentStatusDisabled() {
     PartyDTO partyDTO = partyDTOs.get(3);
-    assertEquals("DISABLED", actionProcessingService.getEnrolmentStatus(partyDTO));
+    assertEquals(actionProcessingService.DISABLED, actionProcessingService.getEnrolmentStatus(partyDTO));
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidatorTest.java
@@ -1,31 +1,19 @@
 package uk.gov.ons.ctp.response.action.service.impl;
 
-import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.ons.ctp.response.action.domain.model.ActionType;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionRequest;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
-import uk.gov.ons.ctp.response.action.service.impl.ActionRequestValidator.*;
 
 
 @RunWith(MockitoJUnitRunner.class)
 public class ActionRequestValidatorTest {
 
-    @InjectMocks
-    private ActionRequestValidator validator;
-
-    /**
-     * Initialises Mockito and loads Class Fixtures
-     */
-    @Before
-    public void setUp() {
-        MockitoAnnotations.initMocks(this);
-    }
+    private ActionRequestValidator validator = new ActionRequestValidator();
 
     @Test
     public void testValidNotificationLetter() {
@@ -169,7 +157,7 @@ public class ActionRequestValidatorTest {
     }
 
     @Test
-    public void testInvalidNotificationEmailInvaliRespondentStatus() {
+    public void testInvalidNotificationEmailInvalidRespondentStatus() {
         ActionType actionType = buildNotificationEmailActionType();
         ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
                 .withEnrolmentStatus(ActionProcessingServiceImpl.ENABLED)
@@ -180,19 +168,19 @@ public class ActionRequestValidatorTest {
 
 
     private ActionType buildNotificationLetterActionType() {
-        return ActionType.builder().actionTypePK(1).name("BSNOT").build();
+        return ActionType.builder().actionTypePK(1).name("BSNOT").handler(ActionRequestValidator.ACTIONEXPORTER).build();
     }
 
     private ActionType buildReminderLetterActionType() {
-        return ActionType.builder().actionTypePK(2).name("BSREM").build();
+        return ActionType.builder().actionTypePK(2).name("BSREM").handler(ActionRequestValidator.ACTIONEXPORTER).build();
     }
 
     private ActionType buildReminderEmailActionType() {
-        return ActionType.builder().actionTypePK(3).name("BSNE").build();
+        return ActionType.builder().actionTypePK(3).name("BSNE").handler(ActionRequestValidator.NOTIFYGATEWAY).build();
     }
 
     private ActionType buildNotificationEmailActionType() {
         //TODO: Update name when we actually populate the systems with this actiontype
-        return ActionType.builder().actionTypePK(4).name("UNKNOWN").build();
+        return ActionType.builder().actionTypePK(4).name("UNKNOWN").handler(ActionRequestValidator.NOTIFYGATEWAY).build();
     }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidatorTest.java
@@ -124,6 +124,16 @@ public class ActionRequestValidatorTest {
 
         assertFalse(validator.validate(actionType, actionRequest));
     }
+
+    @Test
+    public void testInvalidRemindEmailNullEnromentStatus() {
+        ActionType actionType = buildReminderEmailActionType();
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
+                .withRespondentStatus(ActionRequestValidator.RESPONDENTCREATED).build();
+
+        assertFalse(validator.validate(actionType, actionRequest));
+    }
+
     @Test
     public void testInvalidReminderEmailInvalidEnrolment() {
         ActionType actionType = buildReminderEmailActionType();
@@ -162,6 +172,15 @@ public class ActionRequestValidatorTest {
         ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
                 .withEnrolmentStatus(ActionProcessingServiceImpl.ENABLED)
                 .withRespondentStatus(ActionRequestValidator.RESPONDENTCREATED).build();
+
+        assertFalse(validator.validate(actionType, actionRequest));
+    }
+
+    @Test
+    public void testInvalidNotificationEmailNullRespondentStatus() {
+        ActionType actionType = buildNotificationEmailActionType();
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
+                .withEnrolmentStatus(ActionProcessingServiceImpl.ENABLED).build();
 
         assertFalse(validator.validate(actionType, actionRequest));
     }

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidatorTest.java
@@ -1,0 +1,198 @@
+package uk.gov.ons.ctp.response.action.service.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ons.ctp.response.action.domain.model.ActionType;
+import uk.gov.ons.ctp.response.action.message.instruction.ActionRequest;
+import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
+import uk.gov.ons.ctp.response.action.service.impl.ActionRequestValidator.*;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class ActionRequestValidatorTest {
+
+    @InjectMocks
+    private ActionRequestValidator validator;
+
+    /**
+     * Initialises Mockito and loads Class Fixtures
+     */
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testValidNotificationLetter() {
+        ActionType actionType = buildNotificationLetterActionType();
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
+                .withEnrolmentStatus(ActionProcessingServiceImpl.PENDING)
+                .withRespondentStatus(ActionRequestValidator.RESPONDENTCREATED).build();
+
+        assertTrue(validator.validate(actionType, actionRequest));
+    }
+
+    @Test
+    public void testInvalidNotificationLetterCaseCompleted() {
+        ActionType actionType = buildNotificationLetterActionType();
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.COMPLETE.toString()).build();
+
+        assertFalse(validator.validate(actionType, actionRequest));
+    }
+
+    @Test
+    public void testInvalidNotificationLetterEnrolmentNotPending() {
+        ActionType actionType = buildNotificationLetterActionType();
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
+                .withEnrolmentStatus(ActionProcessingServiceImpl.ENABLED)
+                .withRespondentStatus(ActionRequestValidator.RESPONDENTCREATED).build();
+
+        assertFalse(validator.validate(actionType, actionRequest));
+    }
+
+    @Test
+    public void testInvalidNotifidcationLetterRespondentNotCreated() {
+        ActionType actionType = buildNotificationLetterActionType();
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
+                .withEnrolmentStatus(ActionProcessingServiceImpl.PENDING)
+                .withRespondentStatus(ActionRequestValidator.RESPONDENTACTIVE).build();
+
+        assertFalse(validator.validate(actionType, actionRequest));
+    }
+
+
+    @Test
+    public void testValidReminderLetterPendingEnrolment() {
+        ActionType actionType = buildReminderLetterActionType();
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
+                .withEnrolmentStatus(ActionProcessingServiceImpl.PENDING)
+                .withRespondentStatus(ActionRequestValidator.RESPONDENTCREATED).build();
+
+        assertTrue(validator.validate(actionType, actionRequest));
+    }
+
+    @Test
+    public void testValidReminderLetterEnabledEnrolment() {
+        ActionType actionType = buildReminderLetterActionType();
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
+                .withEnrolmentStatus(ActionProcessingServiceImpl.ENABLED)
+                .withRespondentStatus(ActionRequestValidator.RESPONDENTCREATED).build();
+
+        assertTrue(validator.validate(actionType, actionRequest));
+    }
+
+    @Test
+    public void testInvalidReminderLetterInvalidEnrolment() {
+        ActionType actionType = buildReminderLetterActionType();
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
+                .withEnrolmentStatus(ActionProcessingServiceImpl.SUSPENDED)
+                .withRespondentStatus(ActionRequestValidator.RESPONDENTCREATED)
+                .build();
+
+        assertFalse(validator.validate(actionType, actionRequest));
+    }
+
+    @Test
+    public void testInvalidReminderLetterInvalidRespondentStatus() {
+        ActionType actionType = buildReminderLetterActionType();
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
+                .withRespondentStatus(ActionRequestValidator.RESPONDENTACTIVE)
+                .withEnrolmentStatus(ActionProcessingServiceImpl.PENDING).build();
+
+        assertFalse(validator.validate(actionType, actionRequest));
+    }
+
+    @Test
+    public void testValidReminderEmailCaseInProgress() {
+        ActionType actionType = buildReminderEmailActionType();
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
+                .withEnrolmentStatus(ActionProcessingServiceImpl.ENABLED)
+                .withRespondentStatus(ActionRequestValidator.RESPONDENTACTIVE).build();
+
+        assertTrue(validator.validate(actionType, actionRequest));
+    }
+
+    @Test
+    public void testValidReminderEmailCaseNotStarted() {
+        ActionType actionType = buildReminderEmailActionType();
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.NOTSTARTED.toString())
+                .withEnrolmentStatus(ActionProcessingServiceImpl.ENABLED)
+                .withRespondentStatus(ActionRequestValidator.RESPONDENTACTIVE).build();
+
+        assertTrue(validator.validate(actionType, actionRequest));
+    }
+
+    @Test
+    public void testInvalidReminderEmailInvalidRespondentStatus() {
+        ActionType actionType = buildReminderEmailActionType();
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
+                .withEnrolmentStatus(ActionProcessingServiceImpl.ENABLED)
+                .withRespondentStatus(ActionRequestValidator.RESPONDENTCREATED).build();
+
+        assertFalse(validator.validate(actionType, actionRequest));
+    }
+    @Test
+    public void testInvalidReminderEmailInvalidEnrolment() {
+        ActionType actionType = buildReminderEmailActionType();
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.NOTSTARTED.toString())
+                .withEnrolmentStatus(ActionProcessingServiceImpl.PENDING)
+                .withRespondentStatus(ActionRequestValidator.RESPONDENTACTIVE).build();
+
+        assertFalse(validator.validate(actionType, actionRequest));
+    }
+
+    @Test
+    public void testValidNotificationEmail() {
+        ActionType actionType = buildNotificationEmailActionType();
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
+                .withRespondentStatus(ActionRequestValidator.RESPONDENTACTIVE)
+                .withEnrolmentStatus(ActionProcessingServiceImpl.ENABLED)
+                .build();
+
+        assertTrue(validator.validate(actionType, actionRequest));
+    }
+
+    @Test
+    public void testInvalidNotificationEmailInvalidEnrolment() {
+        ActionType actionType = buildNotificationEmailActionType();
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
+                .withRespondentStatus(ActionRequestValidator.RESPONDENTACTIVE)
+                .withEnrolmentStatus(ActionProcessingServiceImpl.PENDING)
+                .build();
+
+        assertFalse(validator.validate(actionType, actionRequest));
+    }
+
+    @Test
+    public void testInvalidNotificationEmailInvaliRespondentStatus() {
+        ActionType actionType = buildNotificationEmailActionType();
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
+                .withEnrolmentStatus(ActionProcessingServiceImpl.ENABLED)
+                .withRespondentStatus(ActionRequestValidator.RESPONDENTCREATED).build();
+
+        assertFalse(validator.validate(actionType, actionRequest));
+    }
+
+
+    private ActionType buildNotificationLetterActionType() {
+        return ActionType.builder().actionTypePK(1).name("BSNOT").build();
+    }
+
+    private ActionType buildReminderLetterActionType() {
+        return ActionType.builder().actionTypePK(2).name("BSREM").build();
+    }
+
+    private ActionType buildReminderEmailActionType() {
+        return ActionType.builder().actionTypePK(3).name("BSNE").build();
+    }
+
+    private ActionType buildNotificationEmailActionType() {
+        //TODO: Update name when we actually populate the systems with this actiontype
+        return ActionType.builder().actionTypePK(4).name("UNKNOWN").build();
+    }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/impl/ActionRequestValidatorTest.java
@@ -18,7 +18,7 @@ public class ActionRequestValidatorTest {
     @Test
     public void testValidNotificationLetter() {
         ActionType actionType = buildNotificationLetterActionType();
-        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.NOTSTARTED.toString())
                 .withEnrolmentStatus(ActionProcessingServiceImpl.PENDING)
                 .withRespondentStatus(ActionRequestValidator.RESPONDENTCREATED).build();
 
@@ -57,7 +57,7 @@ public class ActionRequestValidatorTest {
     @Test
     public void testValidReminderLetterPendingEnrolment() {
         ActionType actionType = buildReminderLetterActionType();
-        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
+        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.NOTSTARTED.toString())
                 .withEnrolmentStatus(ActionProcessingServiceImpl.PENDING)
                 .withRespondentStatus(ActionRequestValidator.RESPONDENTCREATED).build();
 
@@ -65,11 +65,10 @@ public class ActionRequestValidatorTest {
     }
 
     @Test
-    public void testValidReminderLetterEnabledEnrolment() {
+    public void testValidReminderLetterNoActivity() {
         ActionType actionType = buildReminderLetterActionType();
-        ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
-                .withEnrolmentStatus(ActionProcessingServiceImpl.ENABLED)
-                .withRespondentStatus(ActionRequestValidator.RESPONDENTCREATED).build();
+        ActionRequest actionRequest = ActionRequest.builder()
+                .withCaseGroupStatus(CaseGroupStatus.NOTSTARTED.toString()).build();
 
         assertTrue(validator.validate(actionType, actionRequest));
     }
@@ -78,7 +77,7 @@ public class ActionRequestValidatorTest {
     public void testInvalidReminderLetterInvalidEnrolment() {
         ActionType actionType = buildReminderLetterActionType();
         ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.INPROGRESS.toString())
-                .withEnrolmentStatus(ActionProcessingServiceImpl.SUSPENDED)
+                .withEnrolmentStatus("SUSPENDED")
                 .withRespondentStatus(ActionRequestValidator.RESPONDENTCREATED)
                 .build();
 
@@ -138,7 +137,7 @@ public class ActionRequestValidatorTest {
     public void testInvalidReminderEmailInvalidEnrolment() {
         ActionType actionType = buildReminderEmailActionType();
         ActionRequest actionRequest = ActionRequest.builder().withCaseGroupStatus(CaseGroupStatus.NOTSTARTED.toString())
-                .withEnrolmentStatus(ActionProcessingServiceImpl.PENDING)
+                .withEnrolmentStatus("SUSPENDED")
                 .withRespondentStatus(ActionRequestValidator.RESPONDENTACTIVE).build();
 
         assertFalse(validator.validate(actionType, actionRequest));
@@ -199,7 +198,6 @@ public class ActionRequestValidatorTest {
     }
 
     private ActionType buildNotificationEmailActionType() {
-        //TODO: Update name when we actually populate the systems with this actiontype
         return ActionType.builder().actionTypePK(4).name("UNKNOWN").handler(ActionRequestValidator.NOTIFYGATEWAY).build();
     }
 }

--- a/src/test/resources/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.CaseDetailsDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.CaseDetailsDTO.json
@@ -9,6 +9,7 @@
     "sampleUnitType": "H",
     "createdBy": "me",
     "createdDateTime": 1460732606544,
+    "caseGroupStatus": "COMPLETE",
     "responses": [
       {
         "dateTime": 1460732606544,
@@ -61,6 +62,7 @@
     "sampleUnitType": "Z",
     "createdBy": "me",
     "createdDateTime": 1460732606544,
+    "caseGroupStatus": "INPROGRESS",
     "responses": [
       {
         "dateTime": 1460732606544,
@@ -113,6 +115,7 @@
     "sampleUnitType": "HI",
     "createdBy": "me",
     "createdDateTime": 1460732606544,
+    "caseGroupStatus": "INPROGRESS",
     "responses": [
       {
         "dateTime": 1460732606544,

--- a/src/test/resources/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.CaseDetailsDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.CaseDetailsDTO.json
@@ -9,113 +9,6 @@
     "sampleUnitType": "H",
     "createdBy": "me",
     "createdDateTime": 1460732606544,
-    "caseGroupStatus": "COMPLETE",
-    "responses": [
-      {
-        "dateTime": 1460732606544,
-        "inboundChannel": "ONLINE"
-      }
-    ],
-    "caseEvents": [
-      {
-        "createdDateTime":1460736159699,
-        "category":"GENERAL_ENQUIRY",
-        "subCategory":"subcat",
-        "createdBy":"me",
-        "description":"desc"
-      },
-      {
-        "createdDateTime":1460736159699,
-        "category":"GENERAL_ENQUIRY",
-        "subCategory":"subcat",
-        "createdBy":"me",
-        "description":"desc"
-      },
-      {
-        "createdDateTime":1460736159699,
-        "category":"GENERAL_ENQUIRY",
-        "subCategory":"subcat",
-        "createdBy":"me",
-        "description":"desc"
-      },
-      {
-        "createdDateTime":1460736159699,
-        "category":"GENERAL_ENQUIRY",
-        "subCategory":"subcat",
-        "createdBy":"me",
-        "description":"desc"
-      }
-    ],
-    "caseGroup":
-    {
-      "collectionExerciseId": "c2124abc-10c6-4c7c-885a-779d185a03a4",
-      "sampleUnitRef": "222"
-    }
-  },
-  {
-    "id": "7fac359e-645b-487e-bb02-70536eae51d5",
-    "state": "SAMPLED_INIT",
-    "iac": "bbbb cccc dddd",
-    "actionPlanId": "e71002ac-3575-47eb-b87f-cd9db92bf9a7",
-    "collectionInstrumentId": "",
-    "partyId": "2e6add83-e43d-4f52-954f-4109be506c86",
-    "sampleUnitType": "Z",
-    "createdBy": "me",
-    "createdDateTime": 1460732606544,
-    "caseGroupStatus": "INPROGRESS",
-    "responses": [
-      {
-        "dateTime": 1460732606544,
-        "inboundChannel": "ONLINE"
-      }
-    ],
-    "caseEvents": [
-      {
-        "createdDateTime":1460736159699,
-        "category":"GENERAL_ENQUIRY",
-        "subCategory":"subcat",
-        "createdBy":"me",
-        "description":"desc"
-      },
-      {
-        "createdDateTime":1460736159699,
-        "category":"GENERAL_ENQUIRY",
-        "subCategory":"subcat",
-        "createdBy":"me",
-        "description":"desc"
-      },
-      {
-        "createdDateTime":1460736159699,
-        "category":"GENERAL_ENQUIRY",
-        "subCategory":"subcat",
-        "createdBy":"me",
-        "description":"desc"
-      },
-      {
-        "createdDateTime":1460736159699,
-        "category":"GENERAL_ENQUIRY",
-        "subCategory":"subcat",
-        "createdBy":"me",
-        "description":"desc"
-      }
-    ],
-    "caseGroup":
-    {
-      "collectionExerciseId": "c2124abc-10c6-4c7c-885a-779d185a03a4",
-      "sampleUnitRef": "222"
-    }
-  },
-  {
-    "id": "7fac359e-645b-487e-bb02-70536eae51d6",
-    "state": "SAMPLED_INIT",
-    "iac": "bbbb cccc dddd",
-    "actionPlanId": "e71002ac-3575-47eb-b87f-cd9db92bf9a7",
-    "collectionInstrumentId": "",
-    "partyId": "2e6add83-e43d-4f52-954f-4109be506c86",
-    "sampleUnitType": "HI",
-    "createdBy": "me",
-    "createdDateTime": 1460732606544,
-    "caseGroupStatus": "INPROGRESS",
     "responses": [
       {
         "dateTime": 1460732606544,
@@ -156,7 +49,114 @@
     {
       "collectionExerciseId": "c2124abc-10c6-4c7c-885a-779d185a03a4",
       "sampleUnitRef": "222",
-      "partyId": "2e6add83-e43d-4f52-954f-4109be506c81"
+      "caseGroupStatus": "COMPLETE"
+    }
+  },
+  {
+    "id": "7fac359e-645b-487e-bb02-70536eae51d5",
+    "state": "SAMPLED_INIT",
+    "iac": "bbbb cccc dddd",
+    "actionPlanId": "e71002ac-3575-47eb-b87f-cd9db92bf9a7",
+    "collectionInstrumentId": "",
+    "partyId": "2e6add83-e43d-4f52-954f-4109be506c86",
+    "sampleUnitType": "Z",
+    "createdBy": "me",
+    "createdDateTime": 1460732606544,
+    "responses": [
+      {
+        "dateTime": 1460732606544,
+        "inboundChannel": "ONLINE"
+      }
+    ],
+    "caseEvents": [
+      {
+        "createdDateTime":1460736159699,
+        "category":"GENERAL_ENQUIRY",
+        "subCategory":"subcat",
+        "createdBy":"me",
+        "description":"desc"
+      },
+      {
+        "createdDateTime":1460736159699,
+        "category":"GENERAL_ENQUIRY",
+        "subCategory":"subcat",
+        "createdBy":"me",
+        "description":"desc"
+      },
+      {
+        "createdDateTime":1460736159699,
+        "category":"GENERAL_ENQUIRY",
+        "subCategory":"subcat",
+        "createdBy":"me",
+        "description":"desc"
+      },
+      {
+        "createdDateTime":1460736159699,
+        "category":"GENERAL_ENQUIRY",
+        "subCategory":"subcat",
+        "createdBy":"me",
+        "description":"desc"
+      }
+    ],
+    "caseGroup":
+    {
+      "collectionExerciseId": "c2124abc-10c6-4c7c-885a-779d185a03a4",
+      "sampleUnitRef": "222",
+      "caseGroupStatus": "INPROGRESS"
+    }
+  },
+  {
+    "id": "7fac359e-645b-487e-bb02-70536eae51d6",
+    "state": "SAMPLED_INIT",
+    "iac": "bbbb cccc dddd",
+    "actionPlanId": "e71002ac-3575-47eb-b87f-cd9db92bf9a7",
+    "collectionInstrumentId": "",
+    "partyId": "2e6add83-e43d-4f52-954f-4109be506c86",
+    "sampleUnitType": "HI",
+    "createdBy": "me",
+    "createdDateTime": 1460732606544,
+    "responses": [
+      {
+        "dateTime": 1460732606544,
+        "inboundChannel": "ONLINE"
+      }
+    ],
+    "caseEvents": [
+      {
+        "createdDateTime":1460736159699,
+        "category":"GENERAL_ENQUIRY",
+        "subCategory":"subcat",
+        "createdBy":"me",
+        "description":"desc"
+      },
+      {
+        "createdDateTime":1460736159699,
+        "category":"GENERAL_ENQUIRY",
+        "subCategory":"subcat",
+        "createdBy":"me",
+        "description":"desc"
+      },
+      {
+        "createdDateTime":1460736159699,
+        "category":"GENERAL_ENQUIRY",
+        "subCategory":"subcat",
+        "createdBy":"me",
+        "description":"desc"
+      },
+      {
+        "createdDateTime":1460736159699,
+        "category":"GENERAL_ENQUIRY",
+        "subCategory":"subcat",
+        "createdBy":"me",
+        "description":"desc"
+      }
+    ],
+    "caseGroup":
+    {
+      "collectionExerciseId": "c2124abc-10c6-4c7c-885a-779d185a03a4",
+      "sampleUnitRef": "222",
+      "partyId": "2e6add83-e43d-4f52-954f-4109be506c81",
+      "caseGroupStatus": "INPROGRESS"
     }
   }
 ]

--- a/src/test/resources/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.PartyDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.PartyDTO.json
@@ -15,7 +15,7 @@
           {
             "name": "Joe bloggs",
             "surveyId": "surveyId",
-            "enrolmentStatus": "SUSPENDED"
+            "enrolmentStatus": "PENDING"
           },
           {
             "name": "Dave bloggs",

--- a/src/test/resources/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.PartyDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.PartyDTO.json
@@ -23,6 +23,16 @@
             "enrolmentStatus": "ENABLED"
           }
         ]
+      },
+      {
+        "partyId": "partyID2",
+        "enrolments": [
+          {
+            "name": "Steve bloggs",
+            "surveyId": "surveyId",
+            "enrolmentStatus": "SUSPENDED"
+          }
+        ]
       }
     ]
   },
@@ -101,5 +111,125 @@
         ]
       }
     ]
+  },
+  {
+    "id":"2e6add83-e43d-4f52-954f-4109be506c86",
+    "sampleUnitType":"B",
+    "sampleUnitRef": "222",
+    "attributes": {
+      "entref": "bob",
+      "entname1": "07235235235235235",
+      "entname2": "test@test.com"
+    },
+    "associations": [
+      {
+        "partyId": "partyID",
+        "enrolments": [
+          {
+            "name": "Joe bloggs",
+            "surveyId": "surveyId",
+            "enrolmentStatus": "SUSPENDED"
+          },
+          {
+            "name": "Dave bloggs",
+            "surveyId": "surveyId2",
+            "enrolmentStatus": "ENABLED"
+          }
+        ]
+      },
+      {
+        "partyId": "partyID2",
+        "enrolments": [
+          {
+            "name": "Steve bloggs",
+            "surveyId": "surveyId",
+            "enrolmentStatus": "SUSPENDED"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "associations": [
+      {
+        "enrolments": [
+          {
+            "enrolmentStatus": "ENABLED",
+            "name": "Business Register and Employment Survey",
+            "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+          }
+        ],
+        "partyId": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
+        "sampleUnitRef": "50012345678"
+      }
+    ],
+    "attributes": {
+      "emailAddress": "Jacky.Turner@email.com",
+      "firstName": "Jacky",
+      "lastName": "Turner",
+      "telephone": "7971161859"
+    },
+    "id": "cd592e0f-8d07-407b-b75d-e01fbdae8233",
+    "sampleUnitType": "BI",
+    "status": "ACTIVE"
+  },
+  {
+    "associations": [
+      {
+        "enrolments": [
+          {
+            "enrolmentStatus": "ENABLED",
+            "name": "Business Register and Employment Survey",
+            "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+          }
+        ],
+        "partyId": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
+        "sampleUnitRef": "50012345678"
+      }
+    ],
+    "attributes": {
+      "emailAddress": "Jacky.Turner@email.com",
+      "firstName": "Jacky",
+      "lastName": "Turner",
+      "telephone": "7971161859"
+    },
+    "id": "dd592e0f-8d07-407b-b75d-e01fbdae8233",
+    "sampleUnitType": "BI",
+    "status": "SUSPENDED"
+  },
+  {
+    "associations": [
+      {
+        "enrolments": [
+          {
+            "enrolmentStatus": "ENABLED",
+            "name": "Business Register and Employment Survey",
+            "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+          }
+        ],
+        "partyId": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
+        "sampleUnitRef": "50012345678"
+      }
+    ],
+    "attributes": {
+      "emailAddress": "Jacky.Turner@email.com",
+      "firstName": "Jacky",
+      "lastName": "Turner",
+      "telephone": "7971161859"
+    },
+    "id": "cd592e0f-8d07-407b-b75d-e01fbdae8233",
+    "sampleUnitType": "BI",
+    "status": "CREATED"
+  },
+  {
+    "id":"2e6add83-e43d-4f52-954f-4109be506c86",
+    "sampleUnitType":"B",
+    "sampleUnitRef": "222",
+    "attributes": {
+      "entref": "bob",
+      "entname1": "07235235235235235",
+      "entname2": "test@test.com"
+    },
+    "associations": []
   }
 ]

--- a/src/test/resources/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.PartyDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.PartyDTO.json
@@ -7,7 +7,19 @@
       "entref": "bob",
       "entname1": "07235235235235235",
       "entname2": "test@test.com"
-    }
+    },
+    "associations": [
+      {
+        "partyId": "partyID",
+        "enrolments": [
+          {
+            "name": "Joe bloggs",
+            "surveyId": "surveyId",
+            "enrolmentStatus": "PENDING"
+          }
+        ]
+      }
+    ]
   },
   {
     "id":"2e6add83-e43d-4f52-954f-4109be506c81",
@@ -17,6 +29,18 @@
       "entref": "bob",
       "entname1": "07235235235235236",
       "entname2": "test@test.co.uk"
-    }
+    },
+    "associations": [
+      {
+        "partyId": "partyID",
+        "enrolments": [
+          {
+            "name": "Joe bloggs",
+            "surveyId": "surveyId",
+            "enrolmentStatus": "PENDING"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/src/test/resources/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.PartyDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImplTest.PartyDTO.json
@@ -15,7 +15,12 @@
           {
             "name": "Joe bloggs",
             "surveyId": "surveyId",
-            "enrolmentStatus": "PENDING"
+            "enrolmentStatus": "SUSPENDED"
+          },
+          {
+            "name": "Dave bloggs",
+            "surveyId": "surveyId2",
+            "enrolmentStatus": "ENABLED"
           }
         ]
       }
@@ -38,6 +43,60 @@
             "name": "Joe bloggs",
             "surveyId": "surveyId",
             "enrolmentStatus": "PENDING"
+          },
+          {
+            "name": "Dave bloggs",
+            "surveyId": "surveyId2",
+            "enrolmentStatus": "SUSPENDED"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id":"2e6add83-e43d-4f52-954f-4109be506c81",
+    "sampleUnitType":"HI",
+    "sampleUnitRef": "333",
+    "attributes": {
+      "entref": "bob",
+      "entname1": "07235235235235236",
+      "entname2": "test@test.co.uk"
+    },
+    "associations": [
+      {
+        "partyId": "partyID",
+        "enrolments": [
+          {
+            "name": "Joe bloggs",
+            "surveyId": "surveyId",
+            "enrolmentStatus": "DISABLED"
+          },
+          {
+            "name": "Dave bloggs",
+            "surveyId": "surveyId2",
+            "enrolmentStatus": "SUSPENDED"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id":"2e6add83-e43d-4f52-954f-4109be506c81",
+    "sampleUnitType":"HI",
+    "sampleUnitRef": "333",
+    "attributes": {
+      "entref": "bob",
+      "entname1": "07235235235235236",
+      "entname2": "test@test.co.uk"
+    },
+    "associations": [
+      {
+        "partyId": "partyID",
+        "enrolments": [
+          {
+            "name": "Joe bloggs",
+            "surveyId": "surveyId",
+            "enrolmentStatus": "DISABLED"
           }
         ]
       }


### PR DESCRIPTION
- Populates the classifiers and statuses required for sending notifications/generating print letters.
- Validates these messages against the business rules for whether they are to be sent to handler services for letters and emails.