### PR TITLE
Changing the pause after each execution exercise from 1000 to 3600000…

### DIFF
--- a/src/main/resources/application-cloud.yml
+++ b/src/main/resources/application-cloud.yml
@@ -92,7 +92,7 @@ action-distribution:
  # the thread that executes plans to create the  actions
 plan-execution:
   # pause after each execution exercise
-  delay-milli-seconds: 1000
+  delay-milli-seconds: 3600000
 
  # calling the case svc endpoints
 case-svc:


### PR DESCRIPTION
… milliseconds

@rhiGriff once this change is in you can add the following to the CI jenkins job for actionsvc to increase the frequency of the actionplanjob back to once a second. This might be needed for the RM integration tests to pass. Can discuss if this is not clear.

echo "    plan-execution_delay-milli-seconds: \"1000\"" >> manifest-template.yml