### PR TITLE
Rename action plans for bres

### DIFF
--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -14,3 +14,6 @@ databaseChangeLog:
 
   - include:
       file: database/changes/release-10.47.0/changelog.yml
+
+  - include:
+        file: database/changes/release-10.49.0/changelog.yml

--- a/src/main/resources/database/changes/release-10.47.0/changelog.yml
+++ b/src/main/resources/database/changes/release-10.47.0/changelog.yml
@@ -16,6 +16,6 @@ databaseChangeLog:
       changes:
         - sqlFile:
             comment: Change rule offsets
-            path: change_action_offsets.sql
+            path: change_action_plan_names.sql
             relativeToChangelogFile: true
             splitStatements: false

--- a/src/main/resources/database/changes/release-10.47.0/changelog.yml
+++ b/src/main/resources/database/changes/release-10.47.0/changelog.yml
@@ -16,6 +16,6 @@ databaseChangeLog:
       changes:
         - sqlFile:
             comment: Change rule offsets
-            path: change_action_plan_names.sql
+            path: change_action_offsets.sql
             relativeToChangelogFile: true
             splitStatements: false

--- a/src/main/resources/database/changes/release-10.49.0/change_action_plan_names.sql
+++ b/src/main/resources/database/changes/release-10.49.0/change_action_plan_names.sql
@@ -1,0 +1,7 @@
+UPDATE action.actionplan
+SET name = 'Reminder'
+where name = 'BRES';
+
+UPDATE action.actionplan
+SET name = 'Notification'
+where name = 'Enrolment';

--- a/src/main/resources/database/changes/release-10.49.0/changelog.yml
+++ b/src/main/resources/database/changes/release-10.49.0/changelog.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 10.49.0-1
+      author: Tejas Patel
+      changes:
+        - sqlFile:
+            comment: Change action plan names for BRES
+            path: change_action_plan_names.sql
+            relativeToChangelogFile: true
+            splitStatements: false


### PR DESCRIPTION
Currently 'Enrolment' and 'BRES' don't accurately represent the actionplan[s] for the BRES. Renaming these to 'Notification' and 'Reminder' actionplans.