### PR TITLE
Removed creation of pgcrypto to fix boot error in sample service

### DIFF
--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -2,6 +2,3 @@ CREATE USER actionsvc PASSWORD 'actionsvc'
   NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION INHERIT LOGIN;
 
 CREATE SCHEMA action;
-
--- create postgres extension to allow generation of v4 UUID
-CREATE EXTENSION IF NOT EXISTS "pgcrypto";


### PR DESCRIPTION
Removed explicit creation of pgcrypto extension from schema.sql as this was causing some kind of bizarre race condition with a similar statement in the sample service. 