### PR TITLE
Remove redis locking in ActionDistributor

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
@@ -81,10 +81,7 @@ class ActionDistributor {
 
     try {
       final List<Action> actions = retrieveActions(actionType);
-
-      if (!CollectionUtils.isEmpty(actions)) {
-        processActions(actions, requestCount, cancelCount);
-      }
+      processActions(actions, requestCount, cancelCount);
     } catch (final Exception e) {
       log.error("Failed to process action type {}", actionType, e);
     }
@@ -120,10 +117,8 @@ class ActionDistributor {
   private List<Action> retrieveActions(final ActionType actionType) {
     List<Action> actions = actionRepo.findSubmittedOrCancelledByActionTypeName(actionType.getName(),
             appConfig.getActionDistribution().getRetrievalMax());
-    if (CollectionUtils.isNotEmpty(actions)) {
-      log.debug("RETRIEVED action ids {}", actions.stream().map(a -> a.getActionPK().toString())
-          .collect(Collectors.joining(",")));
-    }
+    log.debug("RETRIEVED action ids {}", actions.stream().map(a -> a.getActionPK().toString())
+        .collect(Collectors.joining(",")));
     return actions;
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
@@ -3,13 +3,8 @@ package uk.gov.ons.ctp.response.action.scheduled.distribution;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Component;
-import uk.gov.ons.ctp.common.distributed.DistributedListManager;
-import uk.gov.ons.ctp.common.distributed.LockingException;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ctp.response.action.config.AppConfig;
 import uk.gov.ons.ctp.response.action.domain.model.Action;
 import uk.gov.ons.ctp.response.action.domain.model.ActionType;
@@ -18,7 +13,6 @@ import uk.gov.ons.ctp.response.action.domain.repository.ActionTypeRepository;
 import uk.gov.ons.ctp.response.action.representation.ActionDTO.ActionState;
 import uk.gov.ons.ctp.response.action.service.ActionProcessingService;
 
-import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -36,11 +30,6 @@ import java.util.stream.Collectors;
 @Slf4j
 class ActionDistributor {
 
-  // WILL NOT WORK WITHOUT THIS NEXT LINE
-  private static final long IMPOSSIBLE_ACTION_ID = 999999999999L;
-  @Autowired
-  private DistributedListManager<BigInteger> actionDistributionListManager;
-
   @Autowired
   private AppConfig appConfig;
 
@@ -53,12 +42,14 @@ class ActionDistributor {
   @Autowired
   private ActionProcessingService actionProcessingService;
 
+
   /**
    * wake up on schedule and check for submitted actions, enrich and distribute them to spring integration channels
    *
    * @return the info for the health endpoint regarding the distribution just performed
    */
-  final DistributionInfo distribute() throws LockingException {
+  @Transactional
+  public DistributionInfo distribute() {
     log.debug("ActionDistributor awoken...");
     final DistributionInfo distInfo = new DistributionInfo();
 
@@ -75,7 +66,7 @@ class ActionDistributor {
     return distInfo;
   }
 
-  private List<InstructionCount> processActionType(final ActionType actionType) throws LockingException {
+  private List<InstructionCount> processActionType(final ActionType actionType) {
     log.debug("Dealing with actionType {}", actionType.getName());
     final InstructionCount requestCount = InstructionCount.builder()
         .actionTypeName(actionType.getName())
@@ -96,8 +87,6 @@ class ActionDistributor {
       }
     } catch (final Exception e) {
       log.error("Failed to process action type {}", actionType, e);
-    } finally {
-      actionDistributionListManager.deleteList(actionType.getName(), true);
     }
     return Arrays.asList(requestCount, cancelCount);
   }
@@ -123,34 +112,17 @@ class ActionDistributor {
   }
 
   /**
-   * Get the oldest page of submitted actions by type - but do not retrieve the
-   * same cases as other CaseSvc' in the cluster
+   * Get the oldest page of submitted actions by type
    *
    * @param actionType the type
    * @return list of actions
-   * @throws LockingException LockingException thrown
    */
-  private List<Action> retrieveActions(final ActionType actionType) throws LockingException {
-    final Pageable pageable = new PageRequest(0, appConfig.getActionDistribution().getRetrievalMax(), new Sort(
-        new Sort.Order(Direction.ASC, "updatedDateTime")));
-
-    final List<BigInteger> excludedActionIds = actionDistributionListManager.findList(actionType.getName(), false);
-    if (!excludedActionIds.isEmpty()) {
-      log.debug("Excluding actions {}", excludedActionIds);
-    }
-    // DO NOT REMOVE THIS NEXT LINE
-    excludedActionIds.add(BigInteger.valueOf(IMPOSSIBLE_ACTION_ID));
-
-    final List<Action> actions = actionRepo
-        .findByActionTypeNameAndStateInAndActionPKNotIn(actionType.getName(),
-            Arrays.asList(ActionState.SUBMITTED, ActionState.CANCEL_SUBMITTED), excludedActionIds, pageable);
-    if (!CollectionUtils.isEmpty(actions)) {
+  private List<Action> retrieveActions(final ActionType actionType) {
+    List<Action> actions = actionRepo.findSubmittedOrCancelledByActionTypeName(actionType.getName(),
+            appConfig.getActionDistribution().getRetrievalMax());
+    if (CollectionUtils.isNotEmpty(actions)) {
       log.debug("RETRIEVED action ids {}", actions.stream().map(a -> a.getActionPK().toString())
           .collect(Collectors.joining(",")));
-      // try and save our list to the distributed store
-      actionDistributionListManager.saveList(actionType.getName(), actions.stream()
-          .map(Action::getActionPK)
-          .collect(Collectors.toList()), true);
     }
     return actions;
   }

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/ActionProcessingServiceImpl.java
@@ -96,7 +96,7 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
    *
    * @param action the action to deal with
    */
-  @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = false, rollbackFor = Exception.class)
+  @Transactional(propagation = Propagation.REQUIRED, readOnly = false, rollbackFor = Exception.class)
   public void processActionRequest(final Action action) throws CTPException {
     log.debug("processing actionRequest with actionid {} caseid {} actionplanFK {}", action.getId(),
         action.getCaseId(), action.getActionPlanFK());
@@ -126,7 +126,7 @@ public class ActionProcessingServiceImpl implements ActionProcessingService {
    *
    * @param action the action to deal with
    */
-  @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = false, rollbackFor = Exception.class)
+  @Transactional(propagation = Propagation.REQUIRED, readOnly = false, rollbackFor = Exception.class)
   public void processActionCancel(final Action action) throws CTPException {
     log.info("processing action cancel for actionid {} caseid {} actionplanFK {}", action.getId(),
         action.getCaseId(), action.getActionPlanFK());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,7 +89,7 @@ data-grid:
 # the thread that sends actions to handlers
 action-distribution:
   # how many actions should we read each time we wake
-  retrieval-max: 1
+  retrieval-max: 200
   # when we fail to send to rabbit how long should we pause for before retry
   retry-sleep-seconds: 30
   # how long to pause after each distribution exercise 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,7 +89,7 @@ data-grid:
 # the thread that sends actions to handlers
 action-distribution:
   # how many actions should we read each time we wake
-  retrieval-max: 200
+  retrieval-max: 1
   # when we fail to send to rabbit how long should we pause for before retry
   retry-sleep-seconds: 30
   # how long to pause after each distribution exercise 

--- a/src/test/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributorTest.java
@@ -71,9 +71,6 @@ public class ActionDistributorTest {
   @Mock
   private ActionProcessingService actionProcessingService;
 
-  @Mock
-  private TransactionTemplate transactionTemplate;
-
   @InjectMocks
   private ActionDistributor actionDistributor;
 

--- a/src/test/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributorTest.java
@@ -9,7 +9,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.support.TransactionTemplate;
 import uk.gov.ons.ctp.common.FixtureHelper;
 import uk.gov.ons.ctp.common.distributed.DistributedListManager;
 import uk.gov.ons.ctp.response.action.config.ActionDistribution;
@@ -18,7 +18,6 @@ import uk.gov.ons.ctp.response.action.domain.model.Action;
 import uk.gov.ons.ctp.response.action.domain.model.ActionType;
 import uk.gov.ons.ctp.response.action.domain.repository.ActionRepository;
 import uk.gov.ons.ctp.response.action.domain.repository.ActionTypeRepository;
-import uk.gov.ons.ctp.response.action.representation.ActionDTO.ActionState;
 import uk.gov.ons.ctp.response.action.service.ActionProcessingService;
 
 import java.math.BigInteger;
@@ -29,8 +28,8 @@ import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyList;
-import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -64,9 +63,6 @@ public class ActionDistributorTest {
   private AppConfig appConfig = new AppConfig();
 
   @Mock
-  private DistributedListManager<BigInteger> actionDistributionListManager;
-
-  @Mock
   private ActionRepository actionRepo;
 
   @Mock
@@ -74,6 +70,9 @@ public class ActionDistributorTest {
 
   @Mock
   private ActionProcessingService actionProcessingService;
+
+  @Mock
+  private TransactionTemplate transactionTemplate;
 
   @InjectMocks
   private ActionDistributor actionDistributor;
@@ -104,8 +103,8 @@ public class ActionDistributorTest {
   @Test
   public void testFailToGetAnyAction() throws Exception {
     when(actionTypeRepo.findAll()).thenReturn(actionTypes);
-    when(actionRepo.findByActionTypeNameAndStateInAndActionPKNotIn(any(String.class), any(List.class),
-        any(List.class), any(Pageable.class))).thenThrow(new RuntimeException("Database access failed"));
+    when(actionRepo.findSubmittedOrCancelledByActionTypeName(any(String.class), anyInt()))
+            .thenThrow(new RuntimeException("Database access failed"));
 
     final DistributionInfo info = actionDistributor.distribute();
     final List<InstructionCount> countList = info.getInstructionCounts();
@@ -122,14 +121,10 @@ public class ActionDistributorTest {
     assertTrue(countList.equals(expectedCountList));
 
     // Assertions for calls in method retrieveActions
-    verify(actionDistributionListManager).findList(eq(HOUSEHOLD_INITIAL_CONTACT), eq(false));
-    verify(actionDistributionListManager).findList(eq(HOUSEHOLD_UPLOAD_IAC), eq(false));
-    verify(actionRepo, times(1)).findByActionTypeNameAndStateInAndActionPKNotIn(
-        eq(HOUSEHOLD_INITIAL_CONTACT), anyListOf(ActionState.class), anyListOf(BigInteger.class), any(Pageable.class));
-    verify(actionRepo, times(1)).findByActionTypeNameAndStateInAndActionPKNotIn(
-        eq(HOUSEHOLD_UPLOAD_IAC), anyListOf(ActionState.class), anyListOf(BigInteger.class), any(Pageable.class));
-    verify(actionDistributionListManager, times(0)).saveList(anyString(), anyList(),
-        anyBoolean());
+    verify(actionRepo, times(1)).findSubmittedOrCancelledByActionTypeName(
+        eq(HOUSEHOLD_INITIAL_CONTACT), anyInt());
+    verify(actionRepo, times(1)).findSubmittedOrCancelledByActionTypeName(
+        eq(HOUSEHOLD_UPLOAD_IAC), anyInt());
 
     // Assertions for calls in actionProcessingService
     verify(actionProcessingService, times(0)).processActionRequest(any(Action.class));
@@ -144,11 +139,11 @@ public class ActionDistributorTest {
   @Test
   public void testHappyPathParentCase() throws Exception {
     when(actionTypeRepo.findAll()).thenReturn(actionTypes);
-    when(actionRepo.findByActionTypeNameAndStateInAndActionPKNotIn(eq(HOUSEHOLD_INITIAL_CONTACT),
-        anyListOf(ActionState.class), anyListOf(BigInteger.class), any(Pageable.class))).thenReturn(
+    when(actionRepo.findSubmittedOrCancelledByActionTypeName(eq(HOUSEHOLD_INITIAL_CONTACT),
+        anyInt())).thenReturn(
         householdInitialContactActions);
-    when(actionRepo.findByActionTypeNameAndStateInAndActionPKNotIn(eq(HOUSEHOLD_UPLOAD_IAC),
-        anyListOf(ActionState.class), anyListOf(BigInteger.class), any(Pageable.class))).thenReturn(
+    when(actionRepo.findSubmittedOrCancelledByActionTypeName(eq(HOUSEHOLD_UPLOAD_IAC),
+        anyInt())).thenReturn(
         householdUploadIACActions);
 
     final DistributionInfo info = actionDistributor.distribute();
@@ -168,14 +163,10 @@ public class ActionDistributorTest {
     verify(actionTypeRepo).findAll();
 
     // Assertions for calls in method retrieveActions
-    verify(actionDistributionListManager).findList(eq(HOUSEHOLD_INITIAL_CONTACT), eq(false));
-    verify(actionDistributionListManager).findList(eq(HOUSEHOLD_UPLOAD_IAC), eq(false));
-    verify(actionRepo, times(1)).findByActionTypeNameAndStateInAndActionPKNotIn(
-        eq(HOUSEHOLD_INITIAL_CONTACT), anyListOf(ActionState.class), anyListOf(BigInteger.class), any(Pageable.class));
-    verify(actionRepo, times(1)).findByActionTypeNameAndStateInAndActionPKNotIn(
-        eq(HOUSEHOLD_UPLOAD_IAC), anyListOf(ActionState.class), anyListOf(BigInteger.class), any(Pageable.class));
-    verify(actionDistributionListManager).saveList(eq(HOUSEHOLD_INITIAL_CONTACT), anyList(), anyBoolean());
-    verify(actionDistributionListManager).saveList(eq(HOUSEHOLD_UPLOAD_IAC), anyList(), anyBoolean());
+    verify(actionRepo, times(1)).findSubmittedOrCancelledByActionTypeName(
+        eq(HOUSEHOLD_INITIAL_CONTACT), anyInt());
+    verify(actionRepo, times(1)).findSubmittedOrCancelledByActionTypeName(
+        eq(HOUSEHOLD_UPLOAD_IAC), anyInt());
 
     // Assertions for calls to actionProcessingService & processActionRequest
     final ArgumentCaptor<Action> actionCaptorForActionRequest = ArgumentCaptor.forClass(Action.class);
@@ -209,11 +200,11 @@ public class ActionDistributorTest {
   @Test
   public void testActionProcessingServiceThrowsException() throws Exception {
     when(actionTypeRepo.findAll()).thenReturn(actionTypes);
-    when(actionRepo.findByActionTypeNameAndStateInAndActionPKNotIn(eq(HOUSEHOLD_INITIAL_CONTACT),
-        anyListOf(ActionState.class), anyListOf(BigInteger.class), any(Pageable.class))).thenReturn(
+    when(actionRepo.findSubmittedOrCancelledByActionTypeName(eq(HOUSEHOLD_INITIAL_CONTACT),
+        anyInt())).thenReturn(
         householdInitialContactActions);
-    when(actionRepo.findByActionTypeNameAndStateInAndActionPKNotIn(eq(HOUSEHOLD_UPLOAD_IAC),
-        anyListOf(ActionState.class), anyListOf(BigInteger.class), any(Pageable.class))).thenReturn(
+    when(actionRepo.findSubmittedOrCancelledByActionTypeName(eq(HOUSEHOLD_UPLOAD_IAC),
+        anyInt())).thenReturn(
         householdUploadIACActions);
     doThrow(new RuntimeException("Database access failed")).when(actionProcessingService).processActionRequest(
         any(Action.class));
@@ -237,14 +228,10 @@ public class ActionDistributorTest {
     verify(actionTypeRepo).findAll();
 
     // Assertions for calls in method retrieveActions
-    verify(actionDistributionListManager).findList(eq(HOUSEHOLD_INITIAL_CONTACT), eq(false));
-    verify(actionDistributionListManager).findList(eq(HOUSEHOLD_UPLOAD_IAC), eq(false));
-    verify(actionRepo, times(1)).findByActionTypeNameAndStateInAndActionPKNotIn(
-        eq(HOUSEHOLD_INITIAL_CONTACT), anyListOf(ActionState.class), anyListOf(BigInteger.class), any(Pageable.class));
-    verify(actionRepo, times(1)).findByActionTypeNameAndStateInAndActionPKNotIn(
-        eq(HOUSEHOLD_UPLOAD_IAC), anyListOf(ActionState.class), anyListOf(BigInteger.class), any(Pageable.class));
-    verify(actionDistributionListManager).saveList(eq(HOUSEHOLD_INITIAL_CONTACT), anyList(), anyBoolean());
-    verify(actionDistributionListManager).saveList(eq(HOUSEHOLD_UPLOAD_IAC), anyList(), anyBoolean());
+    verify(actionRepo, times(1)).findSubmittedOrCancelledByActionTypeName(
+        eq(HOUSEHOLD_INITIAL_CONTACT), anyInt());
+    verify(actionRepo, times(1)).findSubmittedOrCancelledByActionTypeName(
+        eq(HOUSEHOLD_UPLOAD_IAC), anyInt());
 
     // Assertions for calls to actionProcessingService & processActionRequest
     final ArgumentCaptor<Action> actionCaptorForActionRequest = ArgumentCaptor.forClass(Action.class);
@@ -282,11 +269,11 @@ public class ActionDistributorTest {
   @Test
   public void testActionProcessingServiceThrowsExceptionIntermittently() throws Exception {
     when(actionTypeRepo.findAll()).thenReturn(actionTypes);
-    when(actionRepo.findByActionTypeNameAndStateInAndActionPKNotIn(eq(HOUSEHOLD_INITIAL_CONTACT),
-        anyListOf(ActionState.class), anyListOf(BigInteger.class), any(Pageable.class))).thenReturn(
+    when(actionRepo.findSubmittedOrCancelledByActionTypeName(eq(HOUSEHOLD_INITIAL_CONTACT),
+        anyInt())).thenReturn(
         householdInitialContactActions);
-    when(actionRepo.findByActionTypeNameAndStateInAndActionPKNotIn(eq(HOUSEHOLD_UPLOAD_IAC),
-        anyListOf(ActionState.class), anyListOf(BigInteger.class), any(Pageable.class))).thenReturn(
+    when(actionRepo.findSubmittedOrCancelledByActionTypeName(eq(HOUSEHOLD_UPLOAD_IAC),
+        anyInt())).thenReturn(
         householdUploadIACActions);
     doThrow(new RuntimeException("Database access failed")).when(actionProcessingService).processActionRequest(
         eq(householdInitialContactActions.get(0)));
@@ -310,14 +297,10 @@ public class ActionDistributorTest {
     verify(actionTypeRepo).findAll();
 
     // Assertions for calls in method retrieveActions
-    verify(actionDistributionListManager).findList(eq(HOUSEHOLD_INITIAL_CONTACT), eq(false));
-    verify(actionDistributionListManager).findList(eq(HOUSEHOLD_UPLOAD_IAC), eq(false));
-    verify(actionRepo, times(1)).findByActionTypeNameAndStateInAndActionPKNotIn(
-        eq(HOUSEHOLD_INITIAL_CONTACT), anyListOf(ActionState.class), anyListOf(BigInteger.class), any(Pageable.class));
-    verify(actionRepo, times(1)).findByActionTypeNameAndStateInAndActionPKNotIn(
-        eq(HOUSEHOLD_UPLOAD_IAC), anyListOf(ActionState.class), anyListOf(BigInteger.class), any(Pageable.class));
-    verify(actionDistributionListManager).saveList(eq(HOUSEHOLD_INITIAL_CONTACT), anyList(), anyBoolean());
-    verify(actionDistributionListManager).saveList(eq(HOUSEHOLD_UPLOAD_IAC), anyList(), anyBoolean());
+    verify(actionRepo, times(1)).findSubmittedOrCancelledByActionTypeName(
+        eq(HOUSEHOLD_INITIAL_CONTACT), anyInt());
+    verify(actionRepo, times(1)).findSubmittedOrCancelledByActionTypeName(
+        eq(HOUSEHOLD_UPLOAD_IAC), anyInt());
 
     // Assertions for calls to actionProcessingService & processActionRequest
     final ArgumentCaptor<Action> actionCaptorForActionRequest = ArgumentCaptor.forClass(Action.class);


### PR DESCRIPTION
### Background
The action distributor is responsible for processing actions that have been submitted or cancelled.
A pattern had been implemented to distribute the work amongst multiple instances of the action service by: 
1. Fetching a batch of actions
1. Pushing a set of action IDs to Redis
1. Other services would then check to see i those IDs stored in Redis to determine if they are currently being processed.

### What was changed
This changes that process to remove the dependency on Redis and use  postgres SELECT FOR UPDATE SKIP LOCKED to allow multiple instances of the action service to process actions in parallel

### Why is this changing
The logic used to handle the locking of records via Redis has dependencies on more services, more complicated code which is harder to read and maintain

### How to review and test
The changes shouldn't change any existing functionality so all existing tests and functionality should pass unit and acceptance tests

[trello](https://trello.com/c/qPlEbzaW/68-investigate-use-of-select-for-update-skip-locked-in-place-of-the-current-redis-locking-mechanism-when-using-postgres-as-a-queue)