### PR TITLE
Create a manifest file with no envs

### DIFF
--- a/manifest-no-envs.yml
+++ b/manifest-no-envs.yml
@@ -1,0 +1,11 @@
+---
+applications:
+- name: actionsvc
+  instances: 1
+  memory: 1024M
+  path: target/actionsvc.jar
+  timeout: 180
+  services:
+    - rm-pg-db
+    - rm-redis
+    - rm-rabbitmq


### PR DESCRIPTION
We need to override environmental variables at deployment time. If a
variables is specified in the manifest file it isn't being overriden.