### PR TITLE
Store exerciseId and partyId in action.case table

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>casesvc-api</artifactId>
-      <version>10.49.7</version>
+      <version>10.49.15-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/action/domain/model/ActionCase.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/domain/model/ActionCase.java
@@ -60,4 +60,10 @@ public class ActionCase implements Serializable {
 
   @Column(name = "actionplanenddate")
   private Timestamp actionPlanEndDate;
+
+  @Column(name = "collectionexerciseid")
+  private UUID collectionExerciseId;
+
+  @Column(name = "partyid")
+  private UUID partyId;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/impl/CaseNotificationServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/impl/CaseNotificationServiceImpl.java
@@ -44,7 +44,6 @@ public class CaseNotificationServiceImpl implements CaseNotificationService {
   @Override
   @Transactional(propagation = Propagation.REQUIRED, readOnly = false, timeout = TRANSACTION_TIMEOUT)
   public void acceptNotification(final CaseNotification notification) throws CTPException {
-    log.info(notification.toString());
     final String actionPlanIdStr = notification.getActionPlanId();
     final UUID actionPlanId = UUID.fromString(actionPlanIdStr);
     final ActionPlan actionPlan = actionPlanRepo.findById(actionPlanId);

--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -17,3 +17,6 @@ databaseChangeLog:
 
   - include:
         file: database/changes/release-10.49.0/changelog.yml
+
+  - include:
+        file: database/changes/release-10.49.18/changelog.yml

--- a/src/main/resources/database/changes/release-10.49.18/add_additional_columns_to_case.sql
+++ b/src/main/resources/database/changes/release-10.49.18/add_additional_columns_to_case.sql
@@ -1,0 +1,3 @@
+ALTER TABLE action.case
+ADD COLUMN partyid uuid,
+ADD COLUMN collectionexerciseid uuid;

--- a/src/main/resources/database/changes/release-10.49.18/changelog.yml
+++ b/src/main/resources/database/changes/release-10.49.18/changelog.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 10.49.18-1
+      author: Andrew Millar
+      changes:
+        - sqlFile:
+            comment: Add collectionexerciseid and partyid column to case table
+            path: add_additional_columns_to_case.sql
+            relativeToChangelogFile: true
+            splitStatements: false

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/impl/CaseNotificationServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/impl/CaseNotificationServiceImplTest.java
@@ -1,114 +1,114 @@
-package uk.gov.ons.ctp.response.action.service.impl;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-import uk.gov.ons.ctp.common.FixtureHelper;
-import uk.gov.ons.ctp.response.action.domain.model.ActionCase;
-import uk.gov.ons.ctp.response.action.domain.model.ActionPlan;
-import uk.gov.ons.ctp.response.action.domain.repository.ActionCaseRepository;
-import uk.gov.ons.ctp.response.action.domain.repository.ActionPlanRepository;
-import uk.gov.ons.ctp.response.action.service.ActionService;
-import uk.gov.ons.ctp.response.action.service.CaseSvcClientService;
-import uk.gov.ons.ctp.response.action.service.CollectionExerciseClientService;
-import uk.gov.ons.ctp.response.casesvc.message.notification.CaseNotification;
-import uk.gov.ons.ctp.response.casesvc.message.notification.NotificationType;
-import uk.gov.ons.ctp.response.casesvc.representation.CaseDTO;
-import uk.gov.ons.ctp.response.casesvc.representation.CaseDetailsDTO;
-import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupDTO;
-import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
-
-import java.util.List;
-import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-
-/**
- * Tests for the CaseNotificationServiceImpl
- */
-@RunWith(MockitoJUnitRunner.class)
-public class CaseNotificationServiceImplTest {
-
-  private static final String DUMMY_UUID = "7bc5d41b-0549-40b3-ba76-42f6d4cf3991";
-
-  @Mock
-  private ActionCaseRepository actionCaseRepo;
-
-  @Mock
-  private ActionPlanRepository actionPlanRepo;
-
-  @Mock
-  private ActionService actionService;
-
-  @Mock
-  private CaseSvcClientService caseService;
-
-  @Mock
-  private CaseSvcClientService caseSvcClientServiceImpl;
-
-  @Mock
-  private CollectionExerciseClientService collectionSvcClientServiceImpl;
-
-  @Mock
-  private CaseDTO caseDTO;
-
-  @Mock
-  private CaseGroupDTO caseGroupDTO;
-
-  @Mock
-  private CollectionExerciseDTO collectionExerciseDTO;
-
-  @InjectMocks
-  private CaseNotificationServiceImpl caseNotificationService;
-
-  /**
-   * Test calls repository correctly
-   *
-   * @throws Exception exception thrown
-   */
-  @Test
-  public void testAcceptNotification() throws Exception {
-    final CaseNotification caseNotification = new CaseNotification();
-    caseNotification.setActionPlanId(DUMMY_UUID);
-    caseNotification.setCaseId(DUMMY_UUID);
-    caseNotification.setNotificationType(NotificationType.ACTIVATED);
-
-    final ActionPlan actionPlan = new ActionPlan();
-    actionPlan.setActionPlanPK(1);
-
-    when(actionPlanRepo.findById(any())).thenReturn(actionPlan);
-
-    final List<CaseDetailsDTO> caseJson = FixtureHelper.loadClassFixtures(CaseDetailsDTO[].class);
-    final List<CollectionExerciseDTO> collectionExerciseJson = FixtureHelper.loadClassFixtures(
-        CollectionExerciseDTO[].class);
-
-
-    when(caseSvcClientServiceImpl.getCase(UUID.fromString(DUMMY_UUID))).thenReturn(caseJson.get(0));
-    when(collectionSvcClientServiceImpl.getCollectionExercise(caseJson.get(0).getCaseGroup()
-        .getCollectionExerciseId())).thenReturn(collectionExerciseJson.get(0));
-
-    caseNotificationService.acceptNotification(caseNotification);
-
-    final ArgumentCaptor<ActionCase> actionCase = ArgumentCaptor.forClass(ActionCase.class);
-
-    verify(actionCaseRepo, times(1)).save(actionCase.capture());
-
-    final List<ActionCase> caze = actionCase.getAllValues();
-
-    verify(actionCaseRepo, times(1)).flush();
-
-    assertEquals(UUID.fromString(DUMMY_UUID), caze.get(0).getActionPlanId());
-    assertTrue(caze.get(0).getActionPlanStartDate() != null);
-    assertTrue(caze.get(0).getActionPlanEndDate() != null);
-    assertEquals(UUID.fromString(DUMMY_UUID), caze.get(0).getId());
-  }
-}
+//package uk.gov.ons.ctp.response.action.service.impl;
+//
+//import org.junit.Test;
+//import org.junit.runner.RunWith;
+//import org.mockito.ArgumentCaptor;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.runners.MockitoJUnitRunner;
+//import uk.gov.ons.ctp.common.FixtureHelper;
+//import uk.gov.ons.ctp.response.action.domain.model.ActionCase;
+//import uk.gov.ons.ctp.response.action.domain.model.ActionPlan;
+//import uk.gov.ons.ctp.response.action.domain.repository.ActionCaseRepository;
+//import uk.gov.ons.ctp.response.action.domain.repository.ActionPlanRepository;
+//import uk.gov.ons.ctp.response.action.service.ActionService;
+//import uk.gov.ons.ctp.response.action.service.CaseSvcClientService;
+//import uk.gov.ons.ctp.response.action.service.CollectionExerciseClientService;
+//import uk.gov.ons.ctp.response.casesvc.message.notification.CaseNotification;
+//import uk.gov.ons.ctp.response.casesvc.message.notification.NotificationType;
+//import uk.gov.ons.ctp.response.casesvc.representation.CaseDTO;
+//import uk.gov.ons.ctp.response.casesvc.representation.CaseDetailsDTO;
+//import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupDTO;
+//import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
+//
+//import java.util.List;
+//import java.util.UUID;
+//
+//import static org.junit.Assert.assertEquals;
+//import static org.junit.Assert.assertTrue;
+//import static org.mockito.Matchers.any;
+//import static org.mockito.Mockito.times;
+//import static org.mockito.Mockito.verify;
+//import static org.mockito.Mockito.when;
+//
+//
+///**
+// * Tests for the CaseNotificationServiceImpl
+// */
+//@RunWith(MockitoJUnitRunner.class)
+//public class CaseNotificationServiceImplTest {
+//
+//  private static final String DUMMY_UUID = "7bc5d41b-0549-40b3-ba76-42f6d4cf3991";
+//
+//  @Mock
+//  private ActionCaseRepository actionCaseRepo;
+//
+//  @Mock
+//  private ActionPlanRepository actionPlanRepo;
+//
+//  @Mock
+//  private ActionService actionService;
+//
+//  @Mock
+//  private CaseSvcClientService caseService;
+//
+//  @Mock
+//  private CaseSvcClientService caseSvcClientServiceImpl;
+//
+//  @Mock
+//  private CollectionExerciseClientService collectionSvcClientServiceImpl;
+//
+//  @Mock
+//  private CaseDTO caseDTO;
+//
+//  @Mock
+//  private CaseGroupDTO caseGroupDTO;
+//
+//  @Mock
+//  private CollectionExerciseDTO collectionExerciseDTO;
+//
+//  @InjectMocks
+//  private CaseNotificationServiceImpl caseNotificationService;
+//
+//  /**
+//   * Test calls repository correctly
+//   *
+//   * @throws Exception exception thrown
+//   */
+//  @Test
+//  public void testAcceptNotification() throws Exception {
+//    final CaseNotification caseNotification = new CaseNotification();
+//    caseNotification.setActionPlanId(DUMMY_UUID);
+//    caseNotification.setCaseId(DUMMY_UUID);
+//    caseNotification.setNotificationType(NotificationType.ACTIVATED);
+//
+//    final ActionPlan actionPlan = new ActionPlan();
+//    actionPlan.setActionPlanPK(1);
+//
+//    when(actionPlanRepo.findById(any())).thenReturn(actionPlan);
+//
+//    final List<CaseDetailsDTO> caseJson = FixtureHelper.loadClassFixtures(CaseDetailsDTO[].class);
+//    final List<CollectionExerciseDTO> collectionExerciseJson = FixtureHelper.loadClassFixtures(
+//        CollectionExerciseDTO[].class);
+//
+//
+//    when(caseSvcClientServiceImpl.getCase(UUID.fromString(DUMMY_UUID))).thenReturn(caseJson.get(0));
+//    when(collectionSvcClientServiceImpl.getCollectionExercise(caseJson.get(0).getCaseGroup()
+//        .getCollectionExerciseId())).thenReturn(collectionExerciseJson.get(0));
+//
+//    caseNotificationService.acceptNotification(caseNotification);
+//
+//    final ArgumentCaptor<ActionCase> actionCase = ArgumentCaptor.forClass(ActionCase.class);
+//
+//    verify(actionCaseRepo, times(1)).save(actionCase.capture());
+//
+//    final List<ActionCase> caze = actionCase.getAllValues();
+//
+//    verify(actionCaseRepo, times(1)).flush();
+//
+//    assertEquals(UUID.fromString(DUMMY_UUID), caze.get(0).getActionPlanId());
+//    assertTrue(caze.get(0).getActionPlanStartDate() != null);
+//    assertTrue(caze.get(0).getActionPlanEndDate() != null);
+//    assertEquals(UUID.fromString(DUMMY_UUID), caze.get(0).getId());
+//  }
+//}

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/impl/CaseNotificationServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/impl/CaseNotificationServiceImplTest.java
@@ -24,7 +24,8 @@ import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExer
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/impl/CaseNotificationServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/impl/CaseNotificationServiceImplTest.java
@@ -1,114 +1,115 @@
-//package uk.gov.ons.ctp.response.action.service.impl;
-//
-//import org.junit.Test;
-//import org.junit.runner.RunWith;
-//import org.mockito.ArgumentCaptor;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.runners.MockitoJUnitRunner;
-//import uk.gov.ons.ctp.common.FixtureHelper;
-//import uk.gov.ons.ctp.response.action.domain.model.ActionCase;
-//import uk.gov.ons.ctp.response.action.domain.model.ActionPlan;
-//import uk.gov.ons.ctp.response.action.domain.repository.ActionCaseRepository;
-//import uk.gov.ons.ctp.response.action.domain.repository.ActionPlanRepository;
-//import uk.gov.ons.ctp.response.action.service.ActionService;
-//import uk.gov.ons.ctp.response.action.service.CaseSvcClientService;
-//import uk.gov.ons.ctp.response.action.service.CollectionExerciseClientService;
-//import uk.gov.ons.ctp.response.casesvc.message.notification.CaseNotification;
-//import uk.gov.ons.ctp.response.casesvc.message.notification.NotificationType;
-//import uk.gov.ons.ctp.response.casesvc.representation.CaseDTO;
-//import uk.gov.ons.ctp.response.casesvc.representation.CaseDetailsDTO;
-//import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupDTO;
-//import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
-//
-//import java.util.List;
-//import java.util.UUID;
-//
-//import static org.junit.Assert.assertEquals;
-//import static org.junit.Assert.assertTrue;
-//import static org.mockito.Matchers.any;
-//import static org.mockito.Mockito.times;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//
-//
-///**
-// * Tests for the CaseNotificationServiceImpl
-// */
-//@RunWith(MockitoJUnitRunner.class)
-//public class CaseNotificationServiceImplTest {
-//
-//  private static final String DUMMY_UUID = "7bc5d41b-0549-40b3-ba76-42f6d4cf3991";
-//
-//  @Mock
-//  private ActionCaseRepository actionCaseRepo;
-//
-//  @Mock
-//  private ActionPlanRepository actionPlanRepo;
-//
-//  @Mock
-//  private ActionService actionService;
-//
-//  @Mock
-//  private CaseSvcClientService caseService;
-//
-//  @Mock
-//  private CaseSvcClientService caseSvcClientServiceImpl;
-//
-//  @Mock
-//  private CollectionExerciseClientService collectionSvcClientServiceImpl;
-//
-//  @Mock
-//  private CaseDTO caseDTO;
-//
-//  @Mock
-//  private CaseGroupDTO caseGroupDTO;
-//
-//  @Mock
-//  private CollectionExerciseDTO collectionExerciseDTO;
-//
-//  @InjectMocks
-//  private CaseNotificationServiceImpl caseNotificationService;
-//
-//  /**
-//   * Test calls repository correctly
-//   *
-//   * @throws Exception exception thrown
-//   */
-//  @Test
-//  public void testAcceptNotification() throws Exception {
-//    final CaseNotification caseNotification = new CaseNotification();
-//    caseNotification.setActionPlanId(DUMMY_UUID);
-//    caseNotification.setCaseId(DUMMY_UUID);
-//    caseNotification.setNotificationType(NotificationType.ACTIVATED);
-//
-//    final ActionPlan actionPlan = new ActionPlan();
-//    actionPlan.setActionPlanPK(1);
-//
-//    when(actionPlanRepo.findById(any())).thenReturn(actionPlan);
-//
-//    final List<CaseDetailsDTO> caseJson = FixtureHelper.loadClassFixtures(CaseDetailsDTO[].class);
-//    final List<CollectionExerciseDTO> collectionExerciseJson = FixtureHelper.loadClassFixtures(
-//        CollectionExerciseDTO[].class);
-//
-//
-//    when(caseSvcClientServiceImpl.getCase(UUID.fromString(DUMMY_UUID))).thenReturn(caseJson.get(0));
-//    when(collectionSvcClientServiceImpl.getCollectionExercise(caseJson.get(0).getCaseGroup()
-//        .getCollectionExerciseId())).thenReturn(collectionExerciseJson.get(0));
-//
-//    caseNotificationService.acceptNotification(caseNotification);
-//
-//    final ArgumentCaptor<ActionCase> actionCase = ArgumentCaptor.forClass(ActionCase.class);
-//
-//    verify(actionCaseRepo, times(1)).save(actionCase.capture());
-//
-//    final List<ActionCase> caze = actionCase.getAllValues();
-//
-//    verify(actionCaseRepo, times(1)).flush();
-//
-//    assertEquals(UUID.fromString(DUMMY_UUID), caze.get(0).getActionPlanId());
-//    assertTrue(caze.get(0).getActionPlanStartDate() != null);
-//    assertTrue(caze.get(0).getActionPlanEndDate() != null);
-//    assertEquals(UUID.fromString(DUMMY_UUID), caze.get(0).getId());
-//  }
-//}
+package uk.gov.ons.ctp.response.action.service.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ons.ctp.common.FixtureHelper;
+import uk.gov.ons.ctp.response.action.domain.model.ActionCase;
+import uk.gov.ons.ctp.response.action.domain.model.ActionPlan;
+import uk.gov.ons.ctp.response.action.domain.repository.ActionCaseRepository;
+import uk.gov.ons.ctp.response.action.domain.repository.ActionPlanRepository;
+import uk.gov.ons.ctp.response.action.service.ActionService;
+import uk.gov.ons.ctp.response.action.service.CaseSvcClientService;
+import uk.gov.ons.ctp.response.action.service.CollectionExerciseClientService;
+import uk.gov.ons.ctp.response.casesvc.message.notification.CaseNotification;
+import uk.gov.ons.ctp.response.casesvc.message.notification.NotificationType;
+import uk.gov.ons.ctp.response.casesvc.representation.CaseDTO;
+import uk.gov.ons.ctp.response.casesvc.representation.CaseDetailsDTO;
+import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupDTO;
+import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * Tests for the CaseNotificationServiceImpl
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CaseNotificationServiceImplTest {
+
+  private static final String DUMMY_UUID = "7bc5d41b-0549-40b3-ba76-42f6d4cf3991";
+
+  @Mock
+  private ActionCaseRepository actionCaseRepo;
+
+  @Mock
+  private ActionPlanRepository actionPlanRepo;
+
+  @Mock
+  private ActionService actionService;
+
+  @Mock
+  private CaseSvcClientService caseService;
+
+  @Mock
+  private CaseSvcClientService caseSvcClientServiceImpl;
+
+  @Mock
+  private CollectionExerciseClientService collectionSvcClientServiceImpl;
+
+  @Mock
+  private CaseDTO caseDTO;
+
+  @Mock
+  private CaseGroupDTO caseGroupDTO;
+
+  @Mock
+  private CollectionExerciseDTO collectionExerciseDTO;
+
+  @InjectMocks
+  private CaseNotificationServiceImpl caseNotificationService;
+
+  /**
+   * Test calls repository correctly
+   *
+   * @throws Exception exception thrown
+   */
+  @Test
+  public void testAcceptNotification() throws Exception {
+    final CaseNotification caseNotification = new CaseNotification();
+    caseNotification.setActionPlanId(DUMMY_UUID);
+    caseNotification.setCaseId(DUMMY_UUID);
+    caseNotification.setNotificationType(NotificationType.ACTIVATED);
+    caseNotification.setExerciseId(DUMMY_UUID);
+    caseNotification.setPartyId(DUMMY_UUID);
+
+    final ActionPlan actionPlan = new ActionPlan();
+    actionPlan.setActionPlanPK(1);
+
+    when(actionPlanRepo.findById(any())).thenReturn(actionPlan);
+
+    final List<CaseDetailsDTO> caseJson = FixtureHelper.loadClassFixtures(CaseDetailsDTO[].class);
+    final List<CollectionExerciseDTO> collectionExerciseJson = FixtureHelper.loadClassFixtures(
+        CollectionExerciseDTO[].class);
+
+
+    when(caseSvcClientServiceImpl.getCase(UUID.fromString(DUMMY_UUID))).thenReturn(caseJson.get(0));
+    when(collectionSvcClientServiceImpl.getCollectionExercise(UUID.fromString(DUMMY_UUID)))
+            .thenReturn(collectionExerciseJson.get(0));
+
+    caseNotificationService.acceptNotification(caseNotification);
+
+    final ArgumentCaptor<ActionCase> actionCase = ArgumentCaptor.forClass(ActionCase.class);
+
+    verify(actionCaseRepo, times(1)).save(actionCase.capture());
+
+    final List<ActionCase> caze = actionCase.getAllValues();
+
+    verify(actionCaseRepo, times(1)).flush();
+
+    assertEquals(UUID.fromString(DUMMY_UUID), caze.get(0).getActionPlanId());
+    assertNotNull(caze.get(0).getActionPlanStartDate());
+    assertNotNull(caze.get(0).getActionPlanEndDate());
+    assertEquals(UUID.fromString(DUMMY_UUID), caze.get(0).getId());
+  }
+}


### PR DESCRIPTION
- Add new columns, `exerciseId` and `partyId` to the action.case table
- Retrieve the data for these fields from the message being sent from the case service

Works with other PR's
[rm-case-service](https://github.com/ONSdigital/rm-case-service/pull/41)
[rm-casesvc-api](https://github.com/ONSdigital/rm-casesvc-api/pull/16)

[Trello](https://trello.com/c/RfLGapt3/62-extend-representation-of-case-in-action-service)