### PR TITLE
Add social pre notification action type

### DIFF
--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -23,3 +23,6 @@ databaseChangeLog:
 
   - include:
         file: database/changes/release-10.50.0/changelog.yml
+
+  - include:
+        file: database/changes/release-10.50.1/changelog.yml

--- a/src/main/resources/database/changes/release-10.50.1/changelog.yml
+++ b/src/main/resources/database/changes/release-10.50.1/changelog.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 10.50.1-1
+      author: Adam Hawtin
+      changes:
+        - sqlFile:
+            comment: Add social pre-notification action type
+            path: update_action_type_add_social_pre_notification.sql
+            relativeToChangelogFile: true
+            splitStatements: false

--- a/src/main/resources/database/changes/release-10.50.1/update_action_type_add_social_pre_notification.sql
+++ b/src/main/resources/database/changes/release-10.50.1/update_action_type_add_social_pre_notification.sql
@@ -1,0 +1,4 @@
+INSERT INTO action.actiontype
+(actiontypepk, "name", description, handler, cancancel, responserequired)
+VALUES
+(11, 'SOCIALPRENOT', 'Social Pre Notification Letter', 'Printer', 'n', 'n')


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Social surveys have a "Pre Notification" letter that is sent out purely to notify  potential respondents before the actual notification that contains their UAC to access the survey online. This PR adds a pre notification action type to facilitate generating the `.csv` files for the pre notification letters.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Adds the social pre notification type by inserting a row in the actiontype table in a liquibase change script

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run this branch locally, check that the `actiontype` table in the action schema in the database contains the new `SOCIALPRENOT` action type after this service starts up.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
Related changes in actionexporter service: https://github.com/ONSdigital/rm-actionexporter-service/pull/32
Trello card: [Dev task 3A: INT: Create csv file for pre-notification template (8)](https://trello.com/c/6mwgWN5K/145-dev-task-3a-int-create-csv-file-for-pre-notification-template-8)
