### PR TITLE
Rolled out Godaddy logger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>uk.gov.ons.ctp.product</groupId>
         <artifactId>rm-common-config</artifactId>
-        <version>10.49.12</version>
+        <version>10.49.13</version>
     </parent>
 
     <scm>
@@ -259,6 +259,10 @@
             <version>5.0.12.Final</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.godaddy</groupId>
+            <artifactId>logging</artifactId>
+        </dependency>
         <!-- Third party end -->
 
         <!-- Testing -->

--- a/src/main/java/uk/gov/ons/ctp/response/action/ActionSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/ActionSvcApplication.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.response.action;
 
+import com.godaddy.logging.LoggingConfigs;
 import java.math.BigInteger;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.redisson.Redisson;
@@ -66,6 +67,8 @@ public class ActionSvcApplication {
    * @param args These are the optional command line arguments
    */
   public static void main(final String[] args) {
+    LoggingConfigs.setCurrent(LoggingConfigs.getCurrent().useJson());
+
     SpringApplication.run(ActionSvcApplication.class, args);
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/client/CaseSvcClientService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/client/CaseSvcClientService.java
@@ -1,11 +1,12 @@
 package uk.gov.ons.ctp.response.action.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
@@ -31,9 +32,9 @@ import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO;
 import uk.gov.ons.ctp.response.casesvc.representation.CreatedCaseEventDTO;
 
 /** Impl of the service that centralizes all REST calls to the Case service */
-@Slf4j
 @Service
 public class CaseSvcClientService {
+  private static final Logger log = LoggerFactory.getLogger(CaseSvcClientService.class);
 
   @Autowired private AppConfig appConfig;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/client/CollectionExerciseClientService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/client/CollectionExerciseClientService.java
@@ -1,9 +1,10 @@
 package uk.gov.ons.ctp.response.action.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.IOException;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.Cacheable;
@@ -21,9 +22,9 @@ import uk.gov.ons.ctp.response.action.config.AppConfig;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 
 /** Impl of the service that centralizes all REST calls to the Collection Exercise service */
-@Slf4j
 @Service
 public class CollectionExerciseClientService {
+  private static final Logger log = LoggerFactory.getLogger(CollectionExerciseClientService.class);
 
   @Autowired private AppConfig appConfig;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/client/PartySvcClientService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/client/PartySvcClientService.java
@@ -1,10 +1,11 @@
 package uk.gov.ons.ctp.response.action.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
@@ -23,9 +24,9 @@ import uk.gov.ons.ctp.response.action.config.AppConfig;
 import uk.gov.ons.ctp.response.party.representation.PartyDTO;
 
 /** Impl of the service that centralizes all REST calls to the Party service */
-@Slf4j
 @Service
 public class PartySvcClientService {
+  private static final Logger log = LoggerFactory.getLogger(PartySvcClientService.class);
 
   @Autowired private AppConfig appConfig;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/client/SampleSvcClientService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/client/SampleSvcClientService.java
@@ -1,8 +1,9 @@
 package uk.gov.ons.ctp.response.action.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
@@ -18,9 +19,9 @@ import uk.gov.ons.ctp.common.rest.RestUtility;
 import uk.gov.ons.ctp.response.action.config.AppConfig;
 import uk.gov.ons.ctp.response.sample.representation.SampleAttributesDTO;
 
-@Slf4j
 @Service
 public class SampleSvcClientService {
+  private static final Logger log = LoggerFactory.getLogger(SampleSvcClientService.class);
 
   @Autowired private AppConfig appConfig;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/client/SurveySvcClientService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/client/SurveySvcClientService.java
@@ -1,8 +1,9 @@
 package uk.gov.ons.ctp.response.action.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.IOException;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
@@ -19,9 +20,9 @@ import uk.gov.ons.ctp.response.action.config.AppConfig;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 /** Impl of the service that centralizes all REST calls to the Survey service */
-@Slf4j
 @Service
 public class SurveySvcClientService {
+  private static final Logger log = LoggerFactory.getLogger(SurveySvcClientService.class);
 
   @Autowired private AppConfig appConfig;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/endpoint/ActionEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/endpoint/ActionEndpoint.java
@@ -1,10 +1,11 @@
 package uk.gov.ons.ctp.response.action.endpoint;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 import javax.validation.Valid;
-import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -36,8 +37,8 @@ import uk.gov.ons.ctp.response.action.service.ActionService;
 /** The REST endpoint controller for Actions. */
 @RestController
 @RequestMapping(value = "/actions", produces = "application/json")
-@Slf4j
 public final class ActionEndpoint implements CTPEndpoint {
+  private static final Logger log = LoggerFactory.getLogger(ActionEndpoint.class);
 
   public static final String ACTION_NOT_FOUND = "Action not found for id %s";
   public static final String ACTION_NOT_UPDATED = "Action not updated for id %s";

--- a/src/main/java/uk/gov/ons/ctp/response/action/endpoint/ActionPlanEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/endpoint/ActionPlanEndpoint.java
@@ -1,11 +1,12 @@
 package uk.gov.ons.ctp.response.action.endpoint;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import javax.validation.Valid;
-import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -31,8 +32,8 @@ import uk.gov.ons.ctp.response.action.service.ActionPlanService;
 /** The REST endpoint controller for ActionPlans. */
 @RestController
 @RequestMapping(value = "/actionplans", produces = "application/json")
-@Slf4j
 public class ActionPlanEndpoint implements CTPEndpoint {
+  private static final Logger log = LoggerFactory.getLogger(ActionPlanEndpoint.class);
 
   public static final String ACTION_PLAN_NOT_FOUND = "ActionPlan not found for id %s";
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/endpoint/ActionPlanJobEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/endpoint/ActionPlanJobEndpoint.java
@@ -2,11 +2,12 @@ package uk.gov.ons.ctp.response.action.endpoint;
 
 import static uk.gov.ons.ctp.response.action.endpoint.ActionPlanEndpoint.ACTION_PLAN_NOT_FOUND;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 import javax.validation.Valid;
-import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -32,8 +33,8 @@ import uk.gov.ons.ctp.response.action.service.ActionPlanService;
 /** The REST endpoint controller for ActionPlanJobs. */
 @RestController
 @RequestMapping(value = "/actionplans", produces = "application/json")
-@Slf4j
 public class ActionPlanJobEndpoint implements CTPEndpoint {
+  private static final Logger log = LoggerFactory.getLogger(ActionPlanJobEndpoint.class);
 
   public static final String ACTION_PLAN_JOB_NOT_FOUND = "ActionPlanJob not found for id %s";
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/endpoint/ActionRuleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/endpoint/ActionRuleEndpoint.java
@@ -1,10 +1,11 @@
 package uk.gov.ons.ctp.response.action.endpoint;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 import javax.validation.Valid;
-import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -32,8 +33,8 @@ import uk.gov.ons.ctp.response.action.service.ActionTypeService;
 /** The REST endpoint controller for Action Rules. */
 @RestController
 @RequestMapping(value = "/actionrules", produces = "application/json")
-@Slf4j
 public class ActionRuleEndpoint implements CTPEndpoint {
+  private static final Logger log = LoggerFactory.getLogger(ActionRuleEndpoint.class);
 
   public static final String ACTION_PLAN_NOT_FOUND = "ActionPlan with id %s not found";
   public static final String ACTION_TYPE_NOT_FOUND = "ActionType with name %s not found";

--- a/src/main/java/uk/gov/ons/ctp/response/action/message/ActionFeedbackReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/message/ActionFeedbackReceiver.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.action.message;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
@@ -19,8 +20,8 @@ import uk.gov.ons.ctp.response.action.service.FeedbackService;
  */
 @CoverageIgnore
 @MessageEndpoint
-@Slf4j
 public class ActionFeedbackReceiver {
+  private static final Logger log = LoggerFactory.getLogger(ActionFeedbackReceiver.class);
 
   @Autowired private FeedbackService feedbackService;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/message/ActionInstructionPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/message/ActionInstructionPublisher.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.action.message;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -12,9 +13,9 @@ import uk.gov.ons.ctp.response.action.message.instruction.ActionInstruction;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionRequest;
 
 /** This class is used to publish ActionInstructions to the downstream handlers. */
-@Slf4j
 @MessageEndpoint
 public class ActionInstructionPublisher {
+  private static final Logger log = LoggerFactory.getLogger(ActionInstructionPublisher.class);
 
   public static final String ACTION = "Action.";
   public static final String BINDING = ".binding";

--- a/src/main/java/uk/gov/ons/ctp/response/action/message/CaseNotificationReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/message/CaseNotificationReceiver.java
@@ -2,7 +2,8 @@ package uk.gov.ons.ctp.response.action.message;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,8 +17,8 @@ import uk.gov.ons.ctp.response.casesvc.message.notification.CaseNotification;
 /** Message end point for Case notification life cycle messages, please see flows.xml. */
 @CoverageIgnore
 @MessageEndpoint
-@Slf4j
 public class CaseNotificationReceiver {
+  private static final Logger log = LoggerFactory.getLogger(CaseNotificationReceiver.class);
 
   @Autowired private CaseNotificationService caseNotificationService;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/scheduled/ReportScheduler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/scheduled/ReportScheduler.java
@@ -1,8 +1,9 @@
 package uk.gov.ons.ctp.response.action.scheduled;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -15,8 +16,8 @@ import uk.gov.ons.ctp.response.action.service.ActionReportService;
  * The scheduler to trigger reports creation based on a cron expression defined in application.yml
  */
 @Component
-@Slf4j
 public class ReportScheduler {
+  private static final Logger log = LoggerFactory.getLogger(ReportScheduler.class);
 
   private static final String DISTRIBUTED_OBJECT_KEY_REPORT_LATCH = "reportlatch";
   private static final String DISTRIBUTED_OBJECT_KEY_INSTANCE_COUNT = "reportscheduler";

--- a/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
@@ -1,10 +1,11 @@
 package uk.gov.ons.ctp.response.action.scheduled.distribution;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -30,8 +31,8 @@ import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
  * createddatatime, and forwards them to ActionProcessingService.
  */
 @Component
-@Slf4j
 class ActionDistributor {
+  private static final Logger log = LoggerFactory.getLogger(ActionDistributor.class);
 
   @Autowired private AppConfig appConfig;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/DistributionScheduler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/DistributionScheduler.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.action.scheduled.distribution;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
@@ -14,8 +15,8 @@ import org.springframework.stereotype.Component;
  */
 @CoverageIgnore
 @Component
-@Slf4j
 public class DistributionScheduler implements HealthIndicator {
+  private static final Logger log = LoggerFactory.getLogger(DistributionScheduler.class);
 
   private DistributionInfo distributionInfo = new DistributionInfo();
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/scheduled/ingest/CsvIngester.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/scheduled/ingest/CsvIngester.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.response.action.scheduled.ingest;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.File;
 import java.io.FileReader;
 import java.math.BigDecimal;
@@ -20,7 +22,6 @@ import liquibase.util.csv.CSVReader;
 import liquibase.util.csv.opencsv.bean.ColumnPositionMappingStrategy;
 import liquibase.util.csv.opencsv.bean.CsvToBean;
 import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.integration.annotation.MessageEndpoint;
@@ -42,8 +43,8 @@ import uk.gov.ons.ctp.response.action.message.instruction.Priority;
  * service.
  */
 @MessageEndpoint
-@Slf4j
 public class CsvIngester extends CsvToBean<CsvLine> {
+  private static final Logger log = LoggerFactory.getLogger(CsvIngester.class);
 
   private static final String CHANNEL = "csvIngest";
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/scheduled/plan/PlanScheduler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/scheduled/plan/PlanScheduler.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.action.scheduled.plan;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
@@ -14,8 +15,8 @@ import uk.gov.ons.ctp.response.action.service.ActionPlanJobService;
  * details from the AppConfig
  */
 @Component
-@Slf4j
 public class PlanScheduler implements HealthIndicator {
+  private static final Logger log = LoggerFactory.getLogger(PlanScheduler.class);
 
   @Autowired private ActionPlanJobService actionPlanJobServiceImpl;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/ActionPlanJobService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/ActionPlanJobService.java
@@ -2,12 +2,13 @@ package uk.gov.ons.ctp.response.action.service;
 
 import static uk.gov.ons.ctp.common.time.DateTimeUtil.nowUTC;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -22,8 +23,8 @@ import uk.gov.ons.ctp.response.action.domain.repository.ActionPlanRepository;
 import uk.gov.ons.ctp.response.action.representation.ActionPlanJobDTO;
 
 @Service
-@Slf4j
 public class ActionPlanJobService {
+  private static final Logger log = LoggerFactory.getLogger(ActionPlanJobService.class);
 
   public static final String CREATED_BY_SYSTEM = "SYSTEM";
   public static final String NO_ACTIONPLAN_MSG = "ActionPlan not found for id %s";

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/ActionPlanService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/ActionPlanService.java
@@ -1,11 +1,12 @@
 package uk.gov.ons.ctp.response.action.service;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -16,8 +17,8 @@ import uk.gov.ons.ctp.response.action.domain.repository.ActionPlanRepository;
 
 /** Implementation */
 @Service
-@Slf4j
 public class ActionPlanService {
+  private static final Logger log = LoggerFactory.getLogger(ActionPlanService.class);
 
   private static final int TRANSACTION_TIMEOUT = 30;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/ActionProcessingService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/ActionProcessingService.java
@@ -1,7 +1,8 @@
 package uk.gov.ons.ctp.response.action.service;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.Arrays;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,8 +22,9 @@ import uk.gov.ons.ctp.response.action.service.decorator.context.ActionRequestCon
 import uk.gov.ons.ctp.response.action.service.decorator.context.ActionRequestContextFactory;
 import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO;
 
-@Slf4j
 public abstract class ActionProcessingService {
+  private static final Logger log = LoggerFactory.getLogger(ActionProcessingService.class);
+
   public static final String DATE_FORMAT_IN_REMINDER_EMAIL = "dd/MM/yyyy";
   public static final String CANCELLATION_REASON = "Action cancelled by Response Management";
   public static final String ENABLED = "ENABLED";

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/ActionReportService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/ActionReportService.java
@@ -1,14 +1,15 @@
 package uk.gov.ons.ctp.response.action.service;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.response.action.domain.repository.ActionReportRepository;
 
 /** Create report via stored procedure */
 @Service
-@Slf4j
 public class ActionReportService {
+  private static final Logger log = LoggerFactory.getLogger(ActionReportService.class);
 
   @Autowired private ActionReportRepository actionReportRepository;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/ActionRequestValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/ActionRequestValidator.java
@@ -1,14 +1,15 @@
 package uk.gov.ons.ctp.response.action.service;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.response.action.domain.model.ActionType;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionRequest;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
 
-@Slf4j
 @Service
 public class ActionRequestValidator {
+  private static final Logger log = LoggerFactory.getLogger(ActionRequestValidator.class);
 
   public static final String RESPONDENTCREATED = "CREATED";
   public static final String RESPONDENTACTIVE = "ACTIVE";

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/ActionRuleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/ActionRuleService.java
@@ -1,9 +1,10 @@
 package uk.gov.ons.ctp.response.action.service;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -14,8 +15,8 @@ import uk.gov.ons.ctp.response.action.domain.repository.ActionRuleRepository;
 
 /** Implementation */
 @Service
-@Slf4j
 public class ActionRuleService {
+  private static final Logger log = LoggerFactory.getLogger(ActionRuleService.class);
 
   private static final int TRANSACTION_TIMEOUT = 30;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/ActionService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/ActionService.java
@@ -1,12 +1,13 @@
 package uk.gov.ons.ctp.response.action.service;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -35,8 +36,8 @@ import uk.gov.ons.ctp.response.action.representation.ActionDTO.ActionState;
  * entity model.
  */
 @Service
-@Slf4j
 public class ActionService {
+  private static final Logger log = LoggerFactory.getLogger(ActionService.class);
 
   private static final int TRANSACTION_TIMEOUT = 30;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/ActionTypeService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/ActionTypeService.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.action.service;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -9,8 +10,8 @@ import uk.gov.ons.ctp.response.action.domain.repository.ActionTypeRepository;
 
 /** Implementation */
 @Service
-@Slf4j
 public class ActionTypeService {
+  private static final Logger log = LoggerFactory.getLogger(ActionTypeService.class);
 
   @Autowired private ActionTypeRepository actionTypeRepo;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/CaseNotificationService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/CaseNotificationService.java
@@ -1,8 +1,9 @@
 package uk.gov.ons.ctp.response.action.service;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -21,8 +22,8 @@ import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExer
  * events.
  */
 @Service
-@Slf4j
 public class CaseNotificationService {
+  private static final Logger log = LoggerFactory.getLogger(CaseNotificationService.class);
 
   private static final int TRANSACTION_TIMEOUT = 30;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/FeedbackService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/FeedbackService.java
@@ -1,7 +1,8 @@
 package uk.gov.ons.ctp.response.action.service;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -21,9 +22,9 @@ import uk.gov.ons.ctp.response.action.representation.ActionDTO.ActionState;
 import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO;
 
 /** Accept feedback from handlers */
-@Slf4j
 @Service
 public class FeedbackService {
+  private static final Logger log = LoggerFactory.getLogger(FeedbackService.class);
 
   private static final int TRANSACTION_TIMEOUT = 30;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/ActionAndActionPlan.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/ActionAndActionPlan.java
@@ -1,13 +1,14 @@
 package uk.gov.ons.ctp.response.action.service.decorator;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import uk.gov.ons.ctp.response.action.domain.model.Action.ActionPriority;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionRequest;
 import uk.gov.ons.ctp.response.action.message.instruction.Priority;
 import uk.gov.ons.ctp.response.action.service.decorator.context.ActionRequestContext;
 
-@Slf4j
 public class ActionAndActionPlan implements ActionRequestDecorator {
+  private static final Logger log = LoggerFactory.getLogger(ActionAndActionPlan.class);
 
   @Override
   public void decorateActionRequest(ActionRequest actionRequest, ActionRequestContext context) {

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/CaseAndCaseEvent.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/CaseAndCaseEvent.java
@@ -1,14 +1,15 @@
 package uk.gov.ons.ctp.response.action.service.decorator;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionEvent;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionRequest;
 import uk.gov.ons.ctp.response.action.service.decorator.context.ActionRequestContext;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseEventDTO;
 
-@Slf4j
 public class CaseAndCaseEvent implements ActionRequestDecorator {
+  private static final Logger log = LoggerFactory.getLogger(CaseAndCaseEvent.class);
 
   @Override
   public void decorateActionRequest(ActionRequest actionRequest, ActionRequestContext context) {

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/PartyAndContact.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/PartyAndContact.java
@@ -1,11 +1,12 @@
 package uk.gov.ons.ctp.response.action.service.decorator;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionContact;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionRequest;
 import uk.gov.ons.ctp.response.action.service.ActionProcessingService;
@@ -15,8 +16,8 @@ import uk.gov.ons.ctp.response.party.representation.Attributes;
 import uk.gov.ons.ctp.response.party.representation.Enrolment;
 import uk.gov.ons.ctp.response.party.representation.PartyDTO;
 
-@Slf4j
 public class PartyAndContact implements ActionRequestDecorator {
+  private static final Logger log = LoggerFactory.getLogger(PartyAndContact.class);
 
   @Override
   public void decorateActionRequest(ActionRequest actionRequest, ActionRequestContext context) {

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/SampleAttributes.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/SampleAttributes.java
@@ -1,14 +1,15 @@
 package uk.gov.ons.ctp.response.action.service.decorator;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.Map;
 import java.util.Objects;
-import lombok.extern.slf4j.Slf4j;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionAddress;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionRequest;
 import uk.gov.ons.ctp.response.action.service.decorator.context.ActionRequestContext;
 
-@Slf4j
 public class SampleAttributes implements ActionRequestDecorator {
+  private static final Logger log = LoggerFactory.getLogger(SampleAttributes.class);
 
   @Override
   public void decorateActionRequest(ActionRequest actionRequest, ActionRequestContext context) {

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/context/ActionRequestContext.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/context/ActionRequestContext.java
@@ -3,7 +3,6 @@ package uk.gov.ons.ctp.response.action.service.decorator.context;
 import java.util.List;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import uk.gov.ons.ctp.response.action.domain.model.Action;
 import uk.gov.ons.ctp.response.action.domain.model.ActionPlan;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseDetailsDTO;
@@ -13,7 +12,6 @@ import uk.gov.ons.ctp.response.sample.representation.SampleAttributesDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitType;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
 
-@Slf4j
 @Data
 @NoArgsConstructor
 public class ActionRequestContext {

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/context/BusinessActionRequestContextFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/context/BusinessActionRequestContextFactory.java
@@ -1,11 +1,12 @@
 package uk.gov.ons.ctp.response.action.service.decorator.context;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -15,10 +16,11 @@ import uk.gov.ons.ctp.response.party.representation.Association;
 import uk.gov.ons.ctp.response.party.representation.PartyDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitType;
 
-@Slf4j
 @Component
 @Qualifier("business")
 public class BusinessActionRequestContextFactory implements ActionRequestContextFactory {
+  private static final Logger log =
+      LoggerFactory.getLogger(BusinessActionRequestContextFactory.class);
 
   @Autowired private PartySvcClientService partySvcClientService;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/context/DefaultActionRequestContextFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/context/DefaultActionRequestContextFactory.java
@@ -1,7 +1,8 @@
 package uk.gov.ons.ctp.response.action.service.decorator.context;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.response.action.client.CaseSvcClientService;
@@ -17,8 +18,9 @@ import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitTyp
 import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 @Component
-@Slf4j
 public class DefaultActionRequestContextFactory implements ActionRequestContextFactory {
+  private static final Logger log =
+      LoggerFactory.getLogger(DefaultActionRequestContextFactory.class);
 
   @Autowired private ActionPlanRepository actionPlanRepo;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/context/SocialActionRequestContextFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/context/SocialActionRequestContextFactory.java
@@ -1,7 +1,8 @@
 package uk.gov.ons.ctp.response.action.service.decorator.context;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -10,10 +11,11 @@ import uk.gov.ons.ctp.response.action.domain.model.Action;
 import uk.gov.ons.ctp.response.action.domain.repository.ActionCaseRepository;
 import uk.gov.ons.ctp.response.sample.representation.SampleAttributesDTO;
 
-@Slf4j
 @Component
 @Qualifier("social")
 public class SocialActionRequestContextFactory implements ActionRequestContextFactory {
+  private static final Logger log =
+      LoggerFactory.getLogger(SocialActionRequestContextFactory.class);
 
   @Autowired private ActionCaseRepository actionCaseRepo;
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,30 +9,48 @@
     value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p})  %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />
   <property name="SYSLOG_PATTERN"
     value="${LOG_LEVEL_PATTERN:-%5level} %-40.40logger{39} : %message%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />
+  <property name="ISO8601_DATE_FORMAT" value="yyyy-MM-dd'T'HH:mm:ss'Z'" />
 
   <appender name="CLOUD" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
       <providers>
-        <mdc/>
-        <pattern>
-          <pattern>
-            {
-            "created": "%date{ISO8601}",
-            "service": "actionsvc",
-            "level": "%level",
-            "event": "%message"
-            }
-          </pattern>
-        </pattern>
+        <timestamp>
+          <timeZone>UTC</timeZone>
+          <pattern>${ISO8601_DATE_FORMAT}</pattern>
+          <fieldName>created</fieldName>
+        </timestamp>
+        <globalCustomFields>
+          <customFields>{"service":"actionsvc"}</customFields>
+        </globalCustomFields>
+        <message>
+          <fieldName>event</fieldName>
+        </message>
+        <loggerName/>
+        <threadName/>
+        <logLevel>
+          <fieldName>level</fieldName>
+        </logLevel>
         <stackTrace>
           <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
-            <maxDepthPerThrowable>30</maxDepthPerThrowable>
-            <shortenedClassNameLength>20</shortenedClassNameLength>
-            <exclude>^sun\.reflect\..*\.invoke</exclude>
-            <exclude>^net\.sf\.cglib\.proxy\.MethodProxy\.invoke</exclude>
+            <maxDepthPerThrowable>20</maxDepthPerThrowable>
+            <maxLength>1000</maxLength>
+            <shortenedClassNameLength>30</shortenedClassNameLength>
             <rootCauseFirst>true</rootCauseFirst>
+            <exclude>excluded</exclude>
           </throwableConverter>
         </stackTrace>
+        <context/>
+        <jsonMessage/>
+        <mdc>
+          <includeMdcKeyName>included</includeMdcKeyName>
+        </mdc>
+        <contextMap/>
+        <tags/>
+        <logstashMarkers/>
+        <arguments>
+          <includeNonStructuredArguments>true</includeNonStructuredArguments>
+          <nonStructuredArgumentsFieldPrefix>prefix</nonStructuredArgumentsFieldPrefix>
+        </arguments>
       </providers>
     </encoder>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">

--- a/src/test/java/uk/gov/ons/ctp/response/action/endpoint/ActionEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/endpoint/ActionEndpointIT.java
@@ -6,6 +6,8 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
@@ -19,7 +21,6 @@ import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -51,11 +52,11 @@ import uk.gov.ons.tools.rabbit.SimpleMessageListener;
 import uk.gov.ons.tools.rabbit.SimpleMessageSender;
 
 /** Integration tests for action endpoints */
-@Slf4j
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class ActionEndpointIT {
+  private static final Logger log = LoggerFactory.getLogger(ActionEndpointIT.class);
 
   @Autowired private ResourceLoader resourceLoader;
 

--- a/src/test/java/uk/gov/ons/ctp/response/action/endpoint/ActionRuleEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/endpoint/ActionRuleEndpointIT.java
@@ -3,13 +3,14 @@ package uk.gov.ons.ctp.response.action.endpoint;
 import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import javax.transaction.Transactional;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -27,11 +28,11 @@ import uk.gov.ons.ctp.common.utility.Mapzer;
 import uk.gov.ons.ctp.response.action.domain.repository.*;
 import uk.gov.ons.ctp.response.action.representation.*;
 
-@Slf4j
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class ActionRuleEndpointIT {
+  private static final Logger log = LoggerFactory.getLogger(ActionRuleEndpointIT.class);
 
   @Autowired private ResourceLoader resourceLoader;
 

--- a/src/test/java/uk/gov/ons/ctp/response/action/scheduled/PlanSchedulerIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/scheduled/PlanSchedulerIT.java
@@ -9,6 +9,8 @@ import static org.junit.Assert.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
@@ -22,7 +24,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import javax.transaction.Transactional;
 import javax.xml.bind.JAXBContext;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.*;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,11 +65,11 @@ import uk.gov.ons.tools.rabbit.SimpleMessageListener;
 import uk.gov.ons.tools.rabbit.SimpleMessageSender;
 
 /** Integration tests for creating action requests */
-@Slf4j
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class PlanSchedulerIT {
+  private static final Logger log = LoggerFactory.getLogger(PlanSchedulerIT.class);
 
   @Autowired private ResourceLoader resourceLoader;
 


### PR DESCRIPTION
# Motivation and Context
We've agreed to use the Godaddy logger for structured JSON logging, which we are now rolling out to all the Java services.

# What has changed
Replaced all the `@Slf4j` annotations. Updated the logback.xml config.

# How to test?
Run with CLOUD profile and check that the logs are coming out in the correct JSON format.

# Links
Trello: https://trello.com/c/2cLIClJa/348-roll-out-godaddy-logger-to-all-the-other-java-services

Architecture decision: https://github.com/ONSdigital/sdc/blob/master/doc/architecture/decisions/godaddy-structured-json-logging-java.md