### PR TITLE
Bump memory to prevent OutOfMemoryError: Metaspace

### DIFF
--- a/manifest-no-envs.yml
+++ b/manifest-no-envs.yml
@@ -2,7 +2,7 @@
 applications:
 - name: actionsvc
   instances: 1
-  memory: 1024M
+  memory: 1536M
   path: target/actionsvc.jar
   timeout: 180
   services:

--- a/manifest-template.yml
+++ b/manifest-template.yml
@@ -3,7 +3,7 @@ applications:
 - name: actionsvc-SPACE
   instances: INSTANCES
   host: actionsvc-SPACE
-  memory: 1024M
+  memory: 1536M
   path: target/actionsvc.jar
   timeout: 180
   services:

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,7 @@ applications:
 - name: actionsvc
   instances: 1
   host: actionsvc
-  memory: 1024M
+  memory: 1536M
   path: target/actionsvc.jar
   timeout: 180
   services:


### PR DESCRIPTION
# Motivation and Context
We are seeing the action service fall over due to memory constraints in
the CI space causing the acceptance tests to fail. We saw this
previously in collection exercise see
https://github.com/ONSdigital/rm-collection-exercise-service/pull/89

# What has changed
Increased memory by 50%

# How to test?
1. Fly pipeline with this branch and observe for crashed events `cf events rm-action-service-ci`
