### PR TITLE
Make social action types cancellable

### DIFF
--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -38,3 +38,6 @@ databaseChangeLog:
 
   - include:
         file: database/changes/release-12/changelog.yml
+
+  - include:
+        file: database/changes/release-13/changelog.yml

--- a/src/main/resources/database/changes/release-13/changelog.yml
+++ b/src/main/resources/database/changes/release-13/changelog.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+
+- changeSet:
+    id: 13-1
+    author: Adam Hawtin
+    changes:
+    - sqlFile:
+        comment: Make social action types cancellable
+        path: make_social_action_types_cancellable.sql
+        relativeToChangelogFile: true
+        splitStatements: false

--- a/src/main/resources/database/changes/release-13/make_social_action_types_cancellable.sql
+++ b/src/main/resources/database/changes/release-13/make_social_action_types_cancellable.sql
@@ -1,0 +1,2 @@
+UPDATE action.actiontype SET cancancel = true WHERE name = 'SOCIALNOT';
+UPDATE action.actiontype SET cancancel = true WHERE name = 'SOCIALPRENOT';


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Social action types should be cancellable.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Updated the social pre-notification and notification/invitation action types to be cancellable

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build and run the service on this branch, the `cancancel` column should now be true for all the social letter action types. 

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/2jyQfOjw/191-sus005-change-the-status-of-an-lms-case-13