### PR TITLE
Add scripts to remove completed cases from action case table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jdk: openjdk8
 before_install: "cp .maven.settings.xml $HOME/.m2/settings.xml"
 
 script:
-  - mvn fmt:check verify cobertura:cobertura
+  - mvn fmt:check verify cobertura:cobertura-integration-test
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then

--- a/scripts/remove-completed-cases-from-action/1_get_case_ids_of_completed_actionable_cases_to_csv.sql
+++ b/scripts/remove-completed-cases-from-action/1_get_case_ids_of_completed_actionable_cases_to_csv.sql
@@ -1,0 +1,1 @@
+\copy (SELECT id FROM casesvc.case WHERE statefk = 'ACTIONABLE' and casegroupfk in (SELECT casegrouppk FROM casesvc.casegroup WHERE status = 'COMPLETEDBYPHONE' or status = 'NOLONGERREQUIRED' or status = 'COMPLETE')) TO STDOUT WITH CSV

--- a/scripts/remove-completed-cases-from-action/2_create_temporary_table_in_action.sql
+++ b/scripts/remove-completed-cases-from-action/2_create_temporary_table_in_action.sql
@@ -1,0 +1,4 @@
+CREATE TABLE action.temp_cases
+(
+	case_id UUID
+)

--- a/scripts/remove-completed-cases-from-action/3_save_case_ids_to_temp_table.sql
+++ b/scripts/remove-completed-cases-from-action/3_save_case_ids_to_temp_table.sql
@@ -1,1 +1,1 @@
-COPY actionsvc.temp_cases(case_id) FROM STDIN WITH CSV;
+COPY action.temp_cases(case_id) FROM STDIN WITH CSV;

--- a/scripts/remove-completed-cases-from-action/3_save_case_ids_to_temp_table.sql
+++ b/scripts/remove-completed-cases-from-action/3_save_case_ids_to_temp_table.sql
@@ -1,0 +1,1 @@
+COPY actionsvc.temp_cases(case_id) FROM STDIN WITH CSV;

--- a/scripts/remove-completed-cases-from-action/4_delete_completed_cases_from_action.sql
+++ b/scripts/remove-completed-cases-from-action/4_delete_completed_cases_from_action.sql
@@ -1,0 +1,2 @@
+delete from action.case
+WHERE id in (SELECT case_id FROM action.temp_cases)

--- a/scripts/remove-completed-cases-from-action/5_update_state_to_inactionable_of_completed_cases.sql
+++ b/scripts/remove-completed-cases-from-action/5_update_state_to_inactionable_of_completed_cases.sql
@@ -1,0 +1,4 @@
+UPDATE casesvc.case
+SET statefk = 'INACTIONABLE'
+WHERE statefk = 'ACTIONABLE' and casegroupfk in (SELECT casegrouppk FROM casesvc.casegroup
+WHERE status = 'COMPLETEDBYPHONE' or status = 'NOLONGERREQUIRED' or status = 'COMPLETE'));

--- a/scripts/remove-completed-cases-from-action/5_update_state_to_inactionable_of_completed_cases.sql
+++ b/scripts/remove-completed-cases-from-action/5_update_state_to_inactionable_of_completed_cases.sql
@@ -1,4 +1,4 @@
 UPDATE casesvc.case
 SET statefk = 'INACTIONABLE'
 WHERE statefk = 'ACTIONABLE' and casegroupfk in (SELECT casegrouppk FROM casesvc.casegroup
-WHERE status = 'COMPLETEDBYPHONE' or status = 'NOLONGERREQUIRED' or status = 'COMPLETE'));
+WHERE status = 'COMPLETEDBYPHONE' or status = 'NOLONGERREQUIRED' or status = 'COMPLETE');

--- a/scripts/remove-completed-cases-from-action/README.md
+++ b/scripts/remove-completed-cases-from-action/README.md
@@ -15,7 +15,7 @@ psql "{ACTION_POSTGRES_URI}" -f 2_create_temporary_table_in_action.sql
 
 Copy case ids from the csv to temporary table
 ```
-psql "{ACTION_POSTGRES_URI}" -c "COPY actionsvc.temp_cases(case_id) FROM STDIN WITH CSV;" < temp_cases.csv
+psql "{ACTION_POSTGRES_URI}" -c "COPY action.temp_cases(case_id) FROM STDIN WITH CSV;" < temp_cases.csv
 ```
 
 Delete completed cases from action service

--- a/scripts/remove-completed-cases-from-action/README.md
+++ b/scripts/remove-completed-cases-from-action/README.md
@@ -1,0 +1,29 @@
+## Delete completed cases from action service
+This folder contains scripts to delete all cases from the action service that have completed case group statuses.
+
+### Scripts
+Export the case ids of cases that have a completed case group status but are in state actionable to a csv file
+
+```
+psql "{CASE_POSTGRES_URI}" -f 1_get_case_ids_of_completed_actionable_cases_to_csv.sql > temp_cases.csv
+```
+
+Create temporary table for case ids in action service
+```
+psql "{ACTION_POSTGRES_URI}" -f 2_create_temporary_table_in_action.sql
+```
+
+Copy case ids from the csv to temporary table
+```
+psql "{ACTION_POSTGRES_URI}" -c "COPY actionsvc.temp_cases(case_id) FROM STDIN WITH CSV;" < temp_cases.csv
+```
+
+Delete completed cases from action service
+```
+psql "{ACTION_POSTGRES_URI}" -f 4_delete_completed_cases_from_action.sql
+```
+
+Update completed cases states to inactionable
+```
+psql "{CASE_POSTGRES_URI}" -f 5_update_state_to_inactionable_of_completed_cases.sql
+```


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In our pre-production and production environments we have a number of cases in the action case table that should not be there as their case group status is complete. If they are in the action case table actions will be fired against them. These scripts will clean this up removing cases that should not be in this table and stoping actions getting fired against them.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
[Trello] https://trello.com/c/V8twXPlu
<!--- Links to any documentation --> 
<!--- Links to any related PRs -->
