### PR TITLE
Removed uneeded logic when sending INPROGRESS or NOTSTARTED cases to …

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/service/ActionProcessingService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/ActionProcessingService.java
@@ -93,20 +93,14 @@ public abstract class ActionProcessingService {
       final ActionRequest actionRequest = prepareActionRequest(action);
 
       if (actionRequest != null) {
-        if (actionType.getHandler().equals("Field")) {
-          if (actionRequest.getCaseGroupStatus().equals("NOTSTARTED")
-              || actionRequest.getCaseGroupStatus().equals("INPROGRESS")) {
-            actionInstructionPublisher.sendActionInstruction("Field", actionRequest);
-          }
-        } else {
-          actionInstructionPublisher.sendActionInstruction(actionType.getHandler(), actionRequest);
-        }
-        // advise casesvc to create a corresponding caseevent for our action
-        caseSvcClientService.createNewCaseEvent(action, CategoryDTO.CategoryName.ACTION_CREATED);
-      } else {
-        log.with("action_id", action.getId())
-            .error("Unexpected situation. actionType is not defined for action");
+        actionInstructionPublisher.sendActionInstruction(actionType.getHandler(), actionRequest);
       }
+
+      // advise casesvc to create a corresponding caseevent for our action
+      caseSvcClientService.createNewCaseEvent(action, CategoryDTO.CategoryName.ACTION_CREATED);
+    } else {
+      log.with("action_id", action.getId())
+        .error("Unexpected situation. actionType is not defined for action");
     }
   }
 

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/ActionProcessingServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/ActionProcessingServiceTest.java
@@ -557,11 +557,6 @@ public class ActionProcessingServiceTest {
     testThatFieldCasesAreHandledAccordingly(CaseGroupStatus.NOTSTARTED, 1);
   }
 
-  @Test
-  public void testCOMPLETECasesAreNotSentToField() throws Exception {
-    testThatFieldCasesAreHandledAccordingly(CaseGroupStatus.COMPLETE, 0);
-  }
-
   /** Function to test whether cases are sent to field. */
   private void testThatFieldCasesAreHandledAccordingly(
       CaseGroupStatus status, Integer numberOfCalls) throws Exception {


### PR DESCRIPTION
…FWMT

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Logic was put in to send cases to FWMT where appropriate but it was un-necessary as the action service would have handled it already.

# What has changed
Amendment to processActionRequest to remove added logic. 

# How to test?
Run ActionEndpointIT and the ActionProcessingServiceTest

# Links
[https://github.com/ONSdigital/rm-action-service/pull/92](https://github.com/ONSdigital/rm-action-service/pull/92)