### PR TITLE
Add REQUIRES_NEW to transaction for action distribution

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/domain/repository/ActionRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/domain/repository/ActionRepository.java
@@ -72,8 +72,7 @@ public interface ActionRepository extends JpaRepository<Action, BigInteger> {
               + " at.name = :actionTypeName "
               + " AND (a.statefk in ('SUBMITTED', 'CANCEL_SUBMITTED')) "
               + "ORDER BY updatedDateTime asc "
-              + "LIMIT :limit "
-              + "FOR UPDATE SKIP LOCKED",
+              + "LIMIT :limit",
       nativeQuery = true)
   List<Action> findSubmittedOrCancelledByActionTypeName(
       @Param("actionTypeName") String actionTypeName, @Param("limit") int limit);

--- a/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
@@ -91,6 +91,7 @@ class ActionDistributor {
   }
 
   private void processAction(Action action) {
+    log.with("action_id", action.getId().toString()).info("Processing action");
     try {
       ActionProcessingService ap = getActionProcessingService(action);
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
@@ -115,6 +115,12 @@ class ActionDistributor {
 
   private ActionProcessingService getActionProcessingService(Action action) {
     ActionCase actionCase = actionCaseRepo.findById(action.getCaseId());
+
+    if(actionCase == null) {
+      log.with("action", action).error("Cannot find case for action");
+      throw new IllegalStateException();
+    }
+    
     SampleUnitDTO.SampleUnitType caseType =
         SampleUnitDTO.SampleUnitType.valueOf(actionCase.getSampleUnitType());
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
@@ -117,11 +117,11 @@ class ActionDistributor {
   private ActionProcessingService getActionProcessingService(Action action) {
     ActionCase actionCase = actionCaseRepo.findById(action.getCaseId());
 
-    if(actionCase == null) {
+    if (actionCase == null) {
       log.with("action", action).error("Cannot find case for action");
       throw new IllegalStateException();
     }
-    
+
     SampleUnitDTO.SampleUnitType caseType =
         SampleUnitDTO.SampleUnitType.valueOf(actionCase.getSampleUnitType());
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
@@ -8,7 +8,6 @@ import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ctp.response.action.client.CaseSvcClientService;
 import uk.gov.ons.ctp.response.action.config.AppConfig;
 import uk.gov.ons.ctp.response.action.domain.model.Action;
@@ -64,7 +63,6 @@ class ActionDistributor {
    * Called on schedule to check for submitted actions then creates and distributes requests to
    * action exporter or notify gateway
    */
-  @Transactional
   public void distribute() {
     List<ActionType> actionTypes = actionTypeRepo.findAll();
     actionTypes.forEach(this::processActionType);

--- a/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/DistributionScheduler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/DistributionScheduler.java
@@ -24,6 +24,10 @@ public class DistributionScheduler {
   /** Scheduled execution of the Action Distributor */
   @Scheduled(fixedDelayString = "#{appConfig.actionDistribution.delayMilliSeconds}")
   public void run() {
-    actionDistributor.distribute();
+    try {
+      actionDistributor.distribute();
+    } catch (Exception ex) {
+      log.error("Uncaught exception", ex);
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/ActionProcessingService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/ActionProcessingService.java
@@ -58,7 +58,7 @@ public abstract class ActionProcessingService {
    *
    * @param action the action to deal with
    */
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void processActionRequests(final Action action) throws CTPException {
     log.with("action_id", action.getId()).debug("Processing actionRequest");
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/ActionProcessingService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/ActionProcessingService.java
@@ -59,7 +59,7 @@ public abstract class ActionProcessingService {
    * @param action the action to deal with
    */
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public void processActionRequests(final Action action) throws CTPException {
+  public void processActionRequests(final Action action) {
     log.with("action_id", action.getId()).debug("Processing actionRequest");
 
     final ActionType actionType = action.getActionType();
@@ -128,7 +128,7 @@ public abstract class ActionProcessingService {
       propagation = Propagation.REQUIRED,
       readOnly = false,
       rollbackFor = Exception.class)
-  public void processActionCancel(final Action action) throws CTPException {
+  public void processActionCancel(final Action action) {
     log.with("action_id", action.getId())
         .with("case_id", action.getCaseId())
         .with("action_plan_pk", action.getActionPlanFK())
@@ -167,10 +167,15 @@ public abstract class ActionProcessingService {
    * @param event the event to transition the action with
    * @throws CTPException if action state transition error
    */
-  private void transitionAction(final Action action, final ActionDTO.ActionEvent event)
-      throws CTPException {
-    final ActionDTO.ActionState nextState =
-        actionSvcStateTransitionManager.transition(action.getState(), event);
+  private void transitionAction(final Action action, final ActionDTO.ActionEvent event) {
+    ActionDTO.ActionState nextState = null;
+
+    try {
+      nextState = actionSvcStateTransitionManager.transition(action.getState(), event);
+    } catch (CTPException ctpExeption) {
+      throw new IllegalStateException();
+    }
+
     action.setState(nextState);
     action.setSituation(null);
     action.setUpdatedDateTime(DateTimeUtil.nowUTC());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,7 +87,7 @@ data-grid:
   # when we try and create a list of ids being distrib how long should we wait to get the lock
   list-time-to-wait-seconds: 10
   #  after app death how long should the lock on all lists remain
-  lock-time-to-live-seconds: 10
+  lock-time-to-live-seconds: 3600
 
   report-lock-time-to-live-seconds: 300
 

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/ActionProcessingServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/ActionProcessingServiceTest.java
@@ -217,7 +217,7 @@ public class ActionProcessingServiceTest {
   }
 
   /** An exception is thrown when transitioning the state of the Action */
-  @Test(expected = CTPException.class)
+  @Test(expected = IllegalStateException.class)
   public void testProcessActionRequestActionStateTransitionThrowsException() throws CTPException {
     // Given
     when(actionSvcStateTransitionManager.transition(
@@ -264,7 +264,7 @@ public class ActionProcessingServiceTest {
   }
 
   /** Scenario where actionSvcStateTransitionManager throws an exception on transition */
-  @Test(expected = CTPException.class)
+  @Test(expected = IllegalStateException.class)
   public void testProcessActionCancelStateTransitionException() throws CTPException {
 
     // Given


### PR DESCRIPTION
# Motivation and Context
Add `REQUIRES_NEW` to transaction for action distribution so actions can be processed individually

# What has changed
Added `propagation = REQUIRES_NEW` to `processActionRequests` method

# How to test?
Actions should be committed to the database individually rather than in batches on in ActionDistributor
Unit/Acceptance tests should pass