### PR TITLE
Remove readonly transaction hint possibly causing JDBC errors

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
@@ -64,7 +64,7 @@ class ActionDistributor {
    * Called on schedule to check for submitted actions then creates and distributes requests to
    * action exporter or notify gateway
    */
-  @Transactional(readOnly = true)
+  @Transactional
   public void distribute() {
     List<ActionType> actionTypes = actionTypeRepo.findAll();
     actionTypes.forEach(this::processActionType);
@@ -91,8 +91,8 @@ class ActionDistributor {
   }
 
   private void processAction(Action action) {
-    log.with("action_id", action.getId().toString()).info("Processing action");
     try {
+      log.with("action_id", action.getId().toString()).info("Processing action");
       ActionProcessingService ap = getActionProcessingService(action);
 
       // If social reminder action type then generate new IAC


### PR DESCRIPTION
# Motivation and Context
Enforcing readonly on the parent transaction was causing an error complaining about "UPDATE in read-only transaction" which should never happen, but we need to fix a prod bug fast, so this is a quick workaround.

# What has changed
Removed readonly from annotation

# How to test?
Run acceptance tests for regression

# Links
Nope