### PR TITLE
Refactor to use stream of actions and reliable transaction boundaries

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/config/ActionDistribution.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/config/ActionDistribution.java
@@ -7,7 +7,6 @@ import net.sourceforge.cobertura.CoverageIgnore;
 @CoverageIgnore
 @Data
 public class ActionDistribution {
-  private Integer retrievalMax;
   private Integer retrySleepSeconds;
   private Integer delayMilliSeconds;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/domain/repository/ActionRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/domain/repository/ActionRepository.java
@@ -2,13 +2,15 @@ package uk.gov.ons.ctp.response.action.domain.repository;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.ons.ctp.response.action.domain.model.Action;
+import uk.gov.ons.ctp.response.action.domain.model.ActionType;
 import uk.gov.ons.ctp.response.action.representation.ActionDTO;
+import uk.gov.ons.ctp.response.action.representation.ActionDTO.ActionState;
 
 /** JPA Data Repository. */
 @Repository
@@ -56,26 +58,7 @@ public interface ActionRepository extends JpaRepository<Action, BigInteger> {
   List<Action> findByActionTypeNameAndStateOrderByCreatedDateTimeDesc(
       String actionTypeName, ActionDTO.ActionState state);
 
-  /**
-   * @param actionTypeName ActionTypeName filter criteria
-   * @param limit how many actions to return at most
-   * @return Return all SUBMITTED or CANCEL_SUBMITTE Dactions for the specified actionTypeName
-   */
-  @Query(
-      value =
-          "SELECT "
-              + " a.* "
-              + "FROM action.action a "
-              + " LEFT OUTER JOIN action.actionType at "
-              + " ON a.actiontypefk = actiontypepk "
-              + "WHERE "
-              + " at.name = :actionTypeName "
-              + " AND (a.statefk in ('SUBMITTED', 'CANCEL_SUBMITTED')) "
-              + "ORDER BY updatedDateTime asc "
-              + "LIMIT :limit",
-      nativeQuery = true)
-  List<Action> findSubmittedOrCancelledByActionTypeName(
-      @Param("actionTypeName") String actionTypeName, @Param("limit") int limit);
+  Stream<Action> findByActionTypeAndStateIn(ActionType actionType, Set<ActionState> states);
 
   /**
    * Return all actions for the specified actionTypeName.

--- a/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
@@ -2,8 +2,11 @@ package uk.gov.ons.ctp.response.action.scheduled.distribution;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
+import com.google.common.collect.Sets;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -64,7 +67,7 @@ class ActionDistributor {
    * Called on schedule to check for submitted actions then creates and distributes requests to
    * action exporter or notify gateway
    */
-  @Transactional
+  @Transactional(timeout = 3600)
   public void distribute() {
     List<ActionType> actionTypes = actionTypeRepo.findAll();
     actionTypes.forEach(this::processActionType);
@@ -76,9 +79,9 @@ class ActionDistributor {
     try {
       if (lock.tryLock(appConfig.getDataGrid().getLockTimeToLiveSeconds(), TimeUnit.SECONDS)) {
         try {
-          List<Action> actions =
-              actionRepo.findSubmittedOrCancelledByActionTypeName(
-                  actionType.getName(), appConfig.getActionDistribution().getRetrievalMax());
+          Set<ActionState> actionStates =
+              Sets.newHashSet(ActionState.SUBMITTED, ActionState.CANCEL_SUBMITTED);
+          Stream<Action> actions = actionRepo.findByActionTypeAndStateIn(actionType, actionStates);
           actions.forEach(this::processAction);
         } finally {
           // Always unlock the distributed lock
@@ -102,9 +105,9 @@ class ActionDistributor {
       }
 
       if (action.getState().equals(ActionState.SUBMITTED)) {
-        ap.processActionRequests(action);
+        ap.processActionRequests(action.getId());
       } else if (action.getState().equals(ActionState.CANCEL_SUBMITTED)) {
-        ap.processActionCancel(action);
+        ap.processActionCancel(action.getId());
       }
     } catch (Exception ex) {
       // We intentionally catch all exceptions here.

--- a/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
@@ -31,6 +31,7 @@ class ActionDistributor {
   private static final Logger log = LoggerFactory.getLogger(ActionDistributor.class);
 
   private static final String LOCK_PREFIX = "ActionDistributionLock-";
+  private static final int TRANSACTION_TIMEOUT_SECONDS = 3600;
 
   private AppConfig appConfig;
   private RedissonClient redissonClient;
@@ -67,7 +68,7 @@ class ActionDistributor {
    * Called on schedule to check for submitted actions then creates and distributes requests to
    * action exporter or notify gateway
    */
-  @Transactional(timeout = 3600)
+  @Transactional(timeout = TRANSACTION_TIMEOUT_SECONDS)
   public void distribute() {
     List<ActionType> actionTypes = actionTypeRepo.findAll();
     actionTypes.forEach(this::processActionType);

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/ActionProcessingService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/ActionProcessingService.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,13 +54,10 @@ public abstract class ActionProcessingService {
     this.decorators = decorators;
   }
 
-  /**
-   * Distributes requests for a single action
-   *
-   * @param action the action to deal with
-   */
+  /** Distributes requests for a single action */
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public void processActionRequests(final Action action) {
+  public void processActionRequests(final UUID actionId) {
+    Action action = actionRepo.findById(actionId);
     log.with("action_id", action.getId()).debug("Processing actionRequest");
 
     final ActionType actionType = action.getActionType();
@@ -119,16 +117,11 @@ public abstract class ActionProcessingService {
     return actionRequest;
   }
 
-  /**
-   * Deal with a single action cancel - the transaction boundary is here
-   *
-   * @param action the action to deal with
-   */
-  @Transactional(
-      propagation = Propagation.REQUIRED,
-      readOnly = false,
-      rollbackFor = Exception.class)
-  public void processActionCancel(final Action action) {
+  /** Deal with a single action cancel - the transaction boundary is here */
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void processActionCancel(final UUID actionId) {
+    Action action = actionRepo.findById(actionId);
+
     log.with("action_id", action.getId())
         .with("case_id", action.getCaseId())
         .with("action_plan_pk", action.getActionPlanFK())

--- a/src/main/resources/application-cloud.yml
+++ b/src/main/resources/application-cloud.yml
@@ -82,13 +82,11 @@ data-grid:
   # when we try and create a list of ids being distrib how long should we wait to get the lock
   list-time-to-wait-seconds: 600
   #  after app death how long should the lock on all lists remain
-  lock-time-to-live-seconds: 600
+  lock-time-to-live-seconds: 3600
   report-lock-time-to-live-seconds: 300
 
 # the thread that sends actions to handlers
 action-distribution:
-  # how many actions should we read each time we wake
-  retrieval-max: 200
   # when we fail to send to rabbit how long should we pause for before retry
   retry-sleep-seconds: 30
   # how long to pause after each distribution exercise

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,8 +93,6 @@ data-grid:
 
 # the thread that sends actions to handlers
 action-distribution:
-  # how many actions should we read each time we wake
-  retrieval-max: 200
   # when we fail to send to rabbit how long should we pause for before retry
   retry-sleep-seconds: 30
   # how long to pause after each distribution exercise


### PR DESCRIPTION
# Motivation and Context
We are able to commit a transaction when we have successfully updated the Action state and sent a Rabbit message for all the associated Action Requests, which constitutes an atomic unit of work. These units of work should have their transactions committed as soon as a discrete unit of work has succeeded.

The scheduler can wake up at whatever interval we want, and retrieve a list of all the Actions which need to be processed, then it should process **as fast as it can** instead of doing batches, with delays in-between each batch.

This should ensure we process as efficiently as possible, as quickly as possible, and with the least number of roundtrips to the database, except to commit its progress, which saves building up a huge transaction log on Postgres and a huge amount of unsent (uncommitted) Rabbit messages.

# What has changed
Returned a stream from the database of all the data we want to process, instead of processing batches. Re-get the entity from the database in the correct transaction context (i.e. the new atomic transaction) instead of passing the entity from the stream.

# How to test?
Run the acceptance tests to check for regression

# Links
Trello: https://trello.com/c/16iAvzJ8/461-bug-production-bug-with-action-service-locking-transaction-batch-problems-causing-distributor-process-to-loop-and-be-unreliable