### PR TITLE
Year added to return by date for FWMT

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/CollectionExerciseAndSurvey.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/decorator/CollectionExerciseAndSurvey.java
@@ -26,7 +26,9 @@ public class CollectionExerciseAndSurvey implements ActionRequestDecorator {
 
       DateFormat dateFormat;
 
-      if (context.getSampleUnitType() == SampleUnitDTO.SampleUnitType.H) {
+      if (context.getSampleUnitType() == SampleUnitDTO.SampleUnitType.H
+          && context.getAction().getActionType().getActionTypeNameEnum()
+              != uk.gov.ons.ctp.response.action.representation.ActionType.SOCIALICF) {
         dateFormat = new SimpleDateFormat(ActionProcessingService.DATE_FORMAT_IN_SOCIAL_LETTER);
       } else {
         dateFormat = new SimpleDateFormat(ActionProcessingService.DATE_FORMAT_IN_REMINDER_EMAIL);

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/ActionServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/ActionServiceTest.java
@@ -238,7 +238,25 @@ public class ActionServiceTest {
     CollectionExerciseAndSurvey decorator = new CollectionExerciseAndSurvey();
     ActionRequest actionRequest = new ActionRequest();
 
-    ActionRequestContext context = createActionRequestContext(SampleUnitDTO.SampleUnitType.H);
+    ActionRequestContext context =
+        createActionRequestContext(SampleUnitDTO.SampleUnitType.H, "SOCIALNOT");
+
+    decorator.decorateActionRequest(actionRequest, context);
+
+    assertThat(actionRequest.getReturnByDate())
+        .isEqualTo(
+            expectedDateFormat.format(
+                context.getCollectionExercise().getScheduledReturnDateTime()));
+  }
+
+  @Test
+  public void ensureReturnByDateFormattedForSocialICF() {
+    SimpleDateFormat expectedDateFormat = new SimpleDateFormat("dd/MM/YYYY");
+    CollectionExerciseAndSurvey decorator = new CollectionExerciseAndSurvey();
+    ActionRequest actionRequest = new ActionRequest();
+
+    ActionRequestContext context =
+        createActionRequestContext(SampleUnitDTO.SampleUnitType.H, "SOCIALICF");
 
     decorator.decorateActionRequest(actionRequest, context);
 
@@ -255,7 +273,8 @@ public class ActionServiceTest {
     CollectionExerciseAndSurvey decorator = new CollectionExerciseAndSurvey();
     ActionRequest actionRequest = new ActionRequest();
 
-    ActionRequestContext context = createActionRequestContext(SampleUnitDTO.SampleUnitType.B);
+    ActionRequestContext context =
+        createActionRequestContext(SampleUnitDTO.SampleUnitType.B, "BSNOT");
 
     decorator.decorateActionRequest(actionRequest, context);
 
@@ -266,7 +285,7 @@ public class ActionServiceTest {
   }
 
   private ActionRequestContext createActionRequestContext(
-      SampleUnitDTO.SampleUnitType sampleUnitType) {
+      SampleUnitDTO.SampleUnitType sampleUnitType, String actionTypeStr) {
     ActionRequestContext context = new ActionRequestContext();
     Date date = new Date();
 
@@ -274,6 +293,12 @@ public class ActionServiceTest {
     collectionExercise.setExerciseRef("123");
     collectionExercise.setUserDescription("Test Description");
     collectionExercise.setScheduledReturnDateTime(new Timestamp(date.getTime()));
+
+    Action action = new Action();
+    ActionType actionType = new ActionType();
+    actionType.setName(actionTypeStr);
+    action.setActionType(actionType);
+    context.setAction(action);
     context.setCollectionExercise(collectionExercise);
 
     SurveyDTO survey = new SurveyDTO();


### PR DESCRIPTION
# Motivation and Context
FWMT tool requires the return by date sent to them to include the year.

# What has changed
SOCIALICF added to clause where it decides which date format to use. A unittest has been added to test that the correct date is used, and the existing social and business unittests have had an action type added to ensure they have the correct date formats.

# How to test?
This can be tested by creating two collection exercises in the rasrm-ops tool locally, one for SOCIALICF and one for SOCIALNOT. Once these are ran, you should see that the messages on the Field RabbitMQ queue have the return by date in the format dd/mm/yyyy, and the messages on the Printer queue should have the return by date in the format dd/mm. 

# Links
https://trello.com/c/kvBHikuB