### PR TITLE
Bug fix include pending enrolments in print file

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/client/PartySvcClientService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/client/PartySvcClientService.java
@@ -78,9 +78,22 @@ public class PartySvcClientService {
         .with("survey_id", surveyId)
         .debug("Retrieving party");
 
+    StringBuilder commaSepEnrolmentStatuses = new StringBuilder();
+
+    for (int i = 0; i < enrolmentStatuses.size(); i++) {
+      commaSepEnrolmentStatuses.append(enrolmentStatuses.get(i));
+
+      if (i != enrolmentStatuses.size() - 1) {
+        commaSepEnrolmentStatuses.append(", ");
+      }
+    }
+
     final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
     queryParams.put("survey_id", Collections.singletonList(surveyId));
-    queryParams.put("enrolment_status", enrolmentStatuses);
+    queryParams.put(
+        "enrolment_status", Collections.singletonList(commaSepEnrolmentStatuses.toString()));
+
+    log.with(queryParams).info("QueryParams");
 
     final UriComponents uriComponents =
         restUtility.createUriComponents(

--- a/src/main/java/uk/gov/ons/ctp/response/action/client/PartySvcClientService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/client/PartySvcClientService.java
@@ -78,15 +78,7 @@ public class PartySvcClientService {
         .with("survey_id", surveyId)
         .debug("Retrieving party");
 
-    StringBuilder commaSepEnrolmentStatuses = new StringBuilder();
-
-    for (int i = 0; i < enrolmentStatuses.size(); i++) {
-      commaSepEnrolmentStatuses.append(enrolmentStatuses.get(i));
-
-      if (i != enrolmentStatuses.size() - 1) {
-        commaSepEnrolmentStatuses.append(", ");
-      }
-    }
+    String commaSepEnrolmentStatuses = String.join(", ", enrolmentStatuses);
 
     final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
     queryParams.put("survey_id", Collections.singletonList(surveyId));

--- a/src/main/java/uk/gov/ons/ctp/response/action/client/PartySvcClientService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/client/PartySvcClientService.java
@@ -76,6 +76,7 @@ public class PartySvcClientService {
     log.with("sample_unit_type", sampleUnitType)
         .with("party_id", partyId.toString())
         .with("survey_id", surveyId)
+        .with("enrolment_statuses", enrolmentStatuses)
         .debug("Retrieving party");
 
     String commaSepEnrolmentStatuses = String.join(", ", enrolmentStatuses);
@@ -85,7 +86,6 @@ public class PartySvcClientService {
     queryParams.put(
         "enrolment_status", Collections.singletonList(commaSepEnrolmentStatuses.toString()));
 
-    log.with(queryParams).info("QueryParams");
 
     final UriComponents uriComponents =
         restUtility.createUriComponents(


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently pending enrolments are missing from the print file this change should fix that.

# What has changed
<!--- What code changes has been made -->
Change query parameter sent of enrolment statuses to party from a list to comma separated string. 
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
When running an action rule with a business that only has a pending enrolment for a survey they party service is called to get respondent details of this pending enrolment.
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
Trello: https://trello.com/c/Cwkh7tWn
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
