### PR TITLE
Only send cancellation if SOCIAL ICF action is found.

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/service/SocialActionProcessingService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/SocialActionProcessingService.java
@@ -68,10 +68,10 @@ public class SocialActionProcessingService extends ActionProcessingService {
       if (at.getName().equals(SOCIAL_ICF)) {
         actionCancel = prepareActionCancel(action);
         log.with("actionCancel", actionCancel).info("Cancellation message.");
+        ActionType actionType = actionTypeRepository.findByName(SOCIAL_ICF);
+        actionInstructionPublisher.sendActionInstruction(actionType.getHandler(), actionCancel);
       }
     }
-    ActionType actionType = actionTypeRepository.findByName(SOCIAL_ICF);
-    actionInstructionPublisher.sendActionInstruction(actionType.getHandler(), actionCancel);
   }
 
   private ActionCancel prepareActionCancel(Action action) {


### PR DESCRIPTION
# Motivation and Context
If no SOCIAL ICF action found it throws a null pointer exception.