### PR TITLE
Add a 1 minute cache evict to collex

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/client/CollectionExerciseClientService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/client/CollectionExerciseClientService.java
@@ -74,6 +74,6 @@ public class CollectionExerciseClientService {
   }
 
   @CacheEvict(cacheNames = "collectionExercise", allEntries = true)
-  @Scheduled(fixedRate = 6000)
+  @Scheduled(fixedRate = 60000)
   public void evictCache() {}
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/client/CollectionExerciseClientService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/client/CollectionExerciseClientService.java
@@ -7,12 +7,14 @@ import java.io.IOException;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -36,7 +38,9 @@ public class CollectionExerciseClientService {
 
   @Autowired private ObjectMapper objectMapper;
 
-  @Cacheable("collectionExercise")
+  private final String CACHE_NAME = "collectionExercise";
+
+  @Cacheable(CACHE_NAME)
   @Retryable(
       value = {RestClientException.class},
       maxAttemptsExpression = "#{${retries.maxAttempts}}",
@@ -70,4 +74,8 @@ public class CollectionExerciseClientService {
     log.with("collection_exercise", result).debug("made call to collection Exercise");
     return result;
   }
+
+  @CacheEvict(cacheNames = CACHE_NAME, allEntries = true)
+  @Scheduled(fixedRate = 6000)
+  public void evictCache() {}
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/client/CollectionExerciseClientService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/client/CollectionExerciseClientService.java
@@ -38,9 +38,7 @@ public class CollectionExerciseClientService {
 
   @Autowired private ObjectMapper objectMapper;
 
-  private final String CACHE_NAME = "collectionExercise";
-
-  @Cacheable(CACHE_NAME)
+  @Cacheable("collectionExercise")
   @Retryable(
       value = {RestClientException.class},
       maxAttemptsExpression = "#{${retries.maxAttempts}}",
@@ -75,7 +73,7 @@ public class CollectionExerciseClientService {
     return result;
   }
 
-  @CacheEvict(cacheNames = CACHE_NAME, allEntries = true)
+  @CacheEvict(cacheNames = "collectionExercise", allEntries = true)
   @Scheduled(fixedRate = 6000)
   public void evictCache() {}
 }


### PR DESCRIPTION
# Motivation and Context
We were having issues with an infinite cache on collection exercise details in this service. This evicts the cache once a minute

# What has changed
Added a `CacheEvict` method on a 6000ms schedule

# How to test?
Not super easy to test really :(