### PR TITLE
Skip actions without cases

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionDistributor.java
@@ -108,6 +108,12 @@ class ActionDistributor {
       log.with("action_id", action.getId().toString()).info("Processing action");
       ActionProcessingService ap = getActionProcessingService(action);
 
+      if (ap == null) {
+        // Case no longer exists for action, has been set to REQUEST_CANCELLED
+        log.with("action_id", action.getId().toString()).info("Skipping action without case");
+        return;
+      }
+
       // If social reminder action type then generate new IAC
       if (action.getActionType().getActionTypeNameEnum()
           == uk.gov.ons.ctp.response.action.representation.ActionType.SOCIALREM) {
@@ -143,6 +149,7 @@ class ActionDistributor {
 
       action.setState(newActionState);
       actionRepo.saveAndFlush(action);
+      return null;
     }
 
     SampleUnitDTO.SampleUnitType caseType =

--- a/src/test/java/uk/gov/ons/ctp/response/action/endpoint/ActionEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/endpoint/ActionEndpointIT.java
@@ -17,7 +17,6 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
-import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import javax.xml.bind.JAXBContext;
@@ -226,7 +225,7 @@ public class ActionEndpointIT {
     ActionRulePostRequestDTO apord = new ActionRulePostRequestDTO();
     apord.setActionPlanId(actionPlanId);
     apord.setActionTypeName(actionType);
-    apord.setName(actionType.toString() + new Random().nextInt(365));
+    apord.setName(actionType.toString() + UUID.randomUUID());
     apord.setDescription("I don't care what you are");
     apord.setPriority(3);
     apord.setTriggerDateTime(OffsetDateTime.now());
@@ -260,7 +259,7 @@ public class ActionEndpointIT {
   private ActionPlanDTO createActionPlan() throws UnirestException {
     ActionPlanPostRequestDTO ap = new ActionPlanPostRequestDTO();
     ap.setCreatedBy("SYSTEM");
-    ap.setName("action-test: " + new Random().nextInt(100));
+    ap.setName("action-test: " + UUID.randomUUID());
     ap.setDescription("just testing!");
 
     HttpResponse<ActionPlanDTO> createActionPlanRes =

--- a/src/test/java/uk/gov/ons/ctp/response/action/scheduled/PlanSchedulerIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/scheduled/PlanSchedulerIT.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
@@ -110,11 +111,11 @@ public class PlanSchedulerIT {
     wireMockRule.resetAll();
     mapzer = new Mapzer(resourceLoader);
     UnirestInitialiser.initialise(objectMapper);
-    actionCaseRepository.deleteAllInBatch();
-    actionRepository.deleteAllInBatch();
-    actionRuleRepository.deleteAllInBatch();
-    actionPlanJobRepository.deleteAllInBatch();
-    actionPlanRepository.deleteAllInBatch();
+    JpaRepository<?, ?>[] repositories = {actionCaseRepository, actionRepository, actionRuleRepository, actionPlanJobRepository, actionPlanRepository};
+    for (JpaRepository<?, ?> repo : repositories) {
+      repo.deleteAllInBatch();
+      repo.flush();
+    }
   }
 
   private ActionPlanDTO createActionPlan() throws UnirestException {


### PR DESCRIPTION
# Motivation and Context
If an action's case was missing for whatever reason, it would correctly be set to `REQUEST_CANCELLED` but then would be processed with a `null` case, causing a `NullPointerException`. This just adds a little bit of logic to skip on to the next action.

After a couple of failed builds, it also fixes a bunch of tests that could randomly fail DB constraints.