### PR TITLE
Up CSV ingester polling interval to an hour

### DIFF
--- a/src/main/resources/springintegration/csvingester-flow.xml
+++ b/src/main/resources/springintegration/csvingester-flow.xml
@@ -12,6 +12,6 @@
     <int-file:inbound-channel-adapter id="csvIngest"
                                       directory="file:${csv-ingest.directory}" prevent-duplicates="false"
                                       filename-pattern="${csv-ingest.file-pattern}">
-        <int:poller fixed-delay="30000" />
+        <int:poller fixed-delay="3600000" />
     </int-file:inbound-channel-adapter>
 </beans>


### PR DESCRIPTION
# Motivation and Context
The CSV ingester aggressively polls for content and it's unnecessary. This ups it from 30 seconds to an hour
