### PR TITLE
Create DNS entries for each service

### DIFF
--- a/_infra/helm/action/Chart.yaml
+++ b/_infra/helm/action/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/_infra/helm/action/templates/deployment.yaml
+++ b/_infra/helm/action/templates/deployment.yaml
@@ -173,17 +173,33 @@ spec:
           - name: LIQUIBASE_URL
             value: "$(SPRING_DATASOURCE_URL)"
           - name: CASE_SVC_CONNECTION_CONFIG_HOST
+            {{- if .Values.dns.enabled }}
+            value: "case.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
             value: "$(CASE_SERVICE_HOST)"
+            {{- end }}
           - name: CASE_SVC_CONNECTION_CONFIG_PORT
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "$(CASE_SERVICE_PORT)"
+            {{- end }}
           - name: CASE_SVC_CONNECTION_CONFIG_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: CASE_SVC_CONNECTION_CONFIG_PASSWORD
             value: "$(SECURITY_USER_PASSWORD)"
           - name: COLLECTION_EXERCISE_SVC_CONNECTION_CONFIG_HOST
+            {{- if .Values.dns.enabled }}
+            value: "collection-exercise.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
             value: "$(COLLECTION_EXERCISE_SERVICE_HOST)"
+            {{- end }}
           - name: COLLECTION_EXERCISE_SVC_CONNECTION_CONFIG_PORT
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "$(COLLECTION_EXERCISE_SERVICE_PORT)"
+            {{- end }}
           - name: COLLECTION_EXERCISE_SVC_CONNECTION_CONFIG_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: COLLECTION_EXERCISE_SVC_CONNECTION_CONFIG_PASSWORD
@@ -209,25 +225,49 @@ spec:
           - name: DATA_GRID_ADDRESS
             value: "$(REDIS_HOST):$(REDIS_PORT)"
           - name: PARTY_SVC_CONNECTION_CONFIG_HOST
+            {{- if .Values.dns.enabled }}
+            value: "party.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
             value: "$(PARTY_SERVICE_HOST)"
+            {{- end }}
           - name: PARTY_SVC_CONNECTION_CONFIG_PORT
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "$(PARTY_SERVICE_PORT)"
+            {{- end }}
           - name: PARTY_SVC_CONNECTION_CONFIG_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: PARTY_SVC_CONNECTION_CONFIG_PASSWORD
             value: "$(SECURITY_USER_PASSWORD)"
           - name: SURVEY_SVC_CONNECTION_CONFIG_HOST
+            {{- if .Values.dns.enabled }}
+            value: "survey.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
             value: "$(SURVEY_SERVICE_HOST)"
+            {{- end }}
           - name: SURVEY_SVC_CONNECTION-CONFIG_PORT
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "$(SURVEY_SERVICE_PORT)"
+            {{- end }}
           - name: SURVEY_SVC_CONNECTION_CONFIG_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: SURVEY_SVC_CONNECTION_CONFIG_PASSWORD
             value: "$(SECURITY_USER_PASSWORD)"
           - name: SAMPLE_SVC_CONNECTION_CONFIG_HOST
-            value: "$(SAMPLE_HOST)"
+            {{- if .Values.dns.enabled }}
+            value: "sample.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
+            value: "$(SAMPLE_SERVICE_HOST)"
+            {{- end }}
           - name: SAMPLE_SVC_CONNECTION_CONFIG_PORT
-            value: "$(SAMPLE_PORT)"
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
+            value: "$(SAMPLE_SERVICE_PORT)"
+            {{- end }}
           - name: SAMPLE_SVC_CONNECTION_CONFIG_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: SAMPLE_SVC_CONNECTION_CONFIG_PASSWORD

--- a/_infra/helm/action/values.yaml
+++ b/_infra/helm/action/values.yaml
@@ -37,3 +37,7 @@ report:
   cron: "0 * * * * *"
 
 planExecutionDelayMillis: 1000
+
+dns:
+  enabled: false
+  wellKnownPort: 8080


### PR DESCRIPTION
# Motivation and Context
Adds kube_dns addresses for all connecting services to allow us to have circular references