### PR TITLE
added image.tag to helm templates

### DIFF
--- a/_infra/helm/action/Chart.yaml
+++ b/_infra/helm/action/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.0
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/_infra/helm/action/templates/deployment.yaml
+++ b/_infra/helm/action/templates/deployment.yaml
@@ -62,7 +62,11 @@ spec:
                 key: db-port
         {{- end }}
         - name: {{ .Chart.Name }}
+          {{- if eq .Values.image.tag "latest"}}
           image: "{{ .Values.image.name }}/{{ .Chart.Name }}:{{ .Chart.AppVersion }}"
+          {{- else}}
+          image: "{{ .Values.image.name }}/{{ .Chart.Name }}:{{ .Values.image.tag }}"
+          {{- end}}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http-server

--- a/_infra/helm/action/values.yaml
+++ b/_infra/helm/action/values.yaml
@@ -7,6 +7,7 @@ rollingUpdate:
 
 image:
   name: eu.gcr.io/ons-rasrmbs-management
+  tag: latest
   pullPolicy: Always
 
 database:


### PR DESCRIPTION
# Motivation and Context
To allow the docker image to be specified in spinnaker 

# What has changed
Docker image tag defaults to AppVersion but can now be overwritten.