### PR TITLE
Fix acceptance test issues around pgcrypto

### DIFF
--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -7,3 +7,5 @@ SET search_path TO action, public;
 
 -- create postgres extension to allow generation of v4 UUID
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+GRANT USAGE ON SCHEMA action TO actionsvc;


### PR DESCRIPTION
# Motivation and Context
Acceptance tests arent running because actionsvc doesnt have the permissions to use `gen_random_uuid`