### PR TITLE
Adding Postgres Dialect setting for preprod/prod

### DIFF
--- a/_infra/helm/action/templates/deployment.yaml
+++ b/_infra/helm/action/templates/deployment.yaml
@@ -164,6 +164,12 @@ spec:
             value: "{{ .Values.report.cron }}"
           - name: PLAN_EXECUTION_DELAY_MILLI_SECONDS
             value: "{{ .Values.planExecutionDelayMillis }}"
+          - name: SPRING_JPA_DATABASE_PLATFORM
+            {{- if .Values.database.sqlProxyEnabled }}
+            value: "org.hibernate.dialect.PostgreSQL94Dialect"
+            {{- else }}
+            value: "org.hibernate.dialect.PostgreSQLDialect"
+            {{- end }}
           - name: SPRING_DATASOURCE_URL
             {{- if .Values.database.sqlProxyEnabled }}
             value: "jdbc:postgresql://127.0.0.1:5432/$(DB_NAME)"


### PR DESCRIPTION
Our Current CF deployment of the application is using a different hibernate dialect to our development environments. Early testing of this appears to fix a print file generation issue (although not confirmed), its possible that this change does nothing and can be removed at a later date but its here to keep things consistent with our cloud foundry environment while we migrate to GCP.