### PR TITLE
Timeout integration tests if they fail

### DIFF
--- a/_infra/helm/action/Chart.yaml
+++ b/_infra/helm/action/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.1.0
+appVersion: 11.1.1

--- a/src/test/java/uk/gov/ons/ctp/response/action/endpoint/ActionEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/endpoint/ActionEndpointIT.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import org.apache.commons.io.IOUtils;
@@ -120,7 +121,7 @@ public class ActionEndpointIT {
     String xml = getCaseNotificationXml(sampleUnitId, case_details_dto, collexId);
     sender.sendMessageToQueue("Case.LifecycleEvents", xml);
 
-    String message = queue.take();
+    String message = queue.poll(1, TimeUnit.MINUTES);
     assertThat(message).isNotNull();
 
     createAction(case_details_dto, ActionType.SOCIALICF);
@@ -131,7 +132,7 @@ public class ActionEndpointIT {
             "action-outbound-exchange",
             "Action.Field.binding");
 
-    String messageToField = queue2.take();
+    String messageToField = queue2.poll(1, TimeUnit.MINUTES);
     assertThat(messageToField).isNotNull();
 
     ActionInstruction actionInstruction = getActionInstructionFromXml(messageToField);
@@ -176,12 +177,12 @@ public class ActionEndpointIT {
     String xml = getCaseNotificationXml(sampleUnitId, case_details_dto, collexId);
     sender.sendMessageToQueue("Case.LifecycleEvents", xml);
 
-    String message = queue.take();
+    String message = queue.poll(1, TimeUnit.MINUTES);
     assertThat(message).isNotNull();
 
     createAction(case_details_dto, ActionType.SOCIALNOT);
 
-    String printer_message = queue2.take();
+    String printer_message = queue2.poll(1, TimeUnit.MINUTES);
     assertThat(printer_message).isNotNull();
 
     log.debug("printer_message = " + printer_message);
@@ -305,7 +306,6 @@ public class ActionEndpointIT {
    */
   private SimpleMessageListener getMessageListener() {
     Rabbitmq config = this.appConfig.getRabbitmq();
-
     return new SimpleMessageListener(
         config.getHost(), config.getPort(), config.getUsername(), config.getPassword());
   }


### PR DESCRIPTION
# Motivation and Context
In some scenarios the integration tests fail but never stop, requiring them to be killed.

This changes the integration test to use a poll with a timeout rather than a take as that can block indefinitely and sometimes leads to the integration tests never finishing. 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
