### PR TITLE
set history limits in both cronjobs

### DIFF
--- a/_infra/helm/action/Chart.yaml
+++ b/_infra/helm/action/Chart.yaml
@@ -18,5 +18,5 @@ version: 1.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.3.10
+appVersion: 11.3.11
 

--- a/_infra/helm/action/templates/distributor-cronjob.yaml
+++ b/_infra/helm/action/templates/distributor-cronjob.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   schedule: "{{ .Values.crons.distributionScheduler.cron }}"
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:

--- a/_infra/helm/action/templates/plan-executor-cronjob.yaml
+++ b/_infra/helm/action/templates/plan-executor-cronjob.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   schedule: "{{ .Values.crons.planJobExecutor.cron }}"
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
# Motivation and Context
To reduce excess repetition of good news in logs, we want to reduce the number of successful cron jobs showing in the history from the default of 3 down to 1. 
<!--- Why is this change required? What problem does it solve? -->

# What has changed
In both cron jobs, set `successfulJobsHistoryLimit` to 1, and explicitly added `failedJobsHistoryLimit` at its default level of 1 alongside, for clarity. 
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
- https://trello.com/c/rlZZ8V8g
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
