### PR TITLE
replace deprecated cmd in GitHub Actions

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: set namespace
         run: |
-          echo ::set-env name=NAMESPACE::$(echo ${{ github.event.comment.body }} | cut -d' ' -f2)
+          echo NAMESPACE=$(echo ${{ github.event.comment.body }} | cut -d' ' -f2) >> $GITHUB_ENV
 
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
     
       - name: package helm
         run: |
-          echo ::set-env name=HELM_VERSION::$(grep -E "version:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g')
+          echo HELM_VERSION=$(grep -E "version:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g') >> $GITHUB_ENV
           helm dep up $CHART_DIRECTORY
           helm package $CHART_DIRECTORY
 

--- a/_infra/helm/action/Chart.yaml
+++ b/_infra/helm/action/Chart.yaml
@@ -18,5 +18,5 @@ version: 1.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.0.3
+appVersion: 12.0.4
 


### PR DESCRIPTION
# Motivation and Context
Replacing `set-env` command in GH Actions, disabled this week for security reasons
<!--- Why is this change required? What problem does it solve? -->

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
https://trello.com/c/5Pj2VUx5
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
