### PR TITLE
Process each action rule individually and in their own transaction

### DIFF
--- a/_infra/helm/action/Chart.yaml
+++ b/_infra/helm/action/Chart.yaml
@@ -18,5 +18,5 @@ version: 1.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.0.6
+appVersion: 12.0.7
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/domain/repository/ActionRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/domain/repository/ActionRepository.java
@@ -6,9 +6,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import uk.gov.ons.ctp.response.action.domain.model.Action;
 import uk.gov.ons.ctp.response.action.domain.model.ActionType;
+import uk.gov.ons.ctp.response.action.representation.ActionDTO;
 import uk.gov.ons.ctp.response.action.representation.ActionDTO.ActionState;
 
 /** JPA Data Repository. */
@@ -41,4 +43,20 @@ public interface ActionRepository extends JpaRepository<Action, BigInteger> {
    * @return Action returns an action is
    */
   boolean existsByCaseIdAndActionRuleFK(UUID caseId, Integer actionRuleFK);
+
+  Stream<Action> findByActionTypeAndActionRuleFKAndStateIn(
+      ActionType actionType, Integer actionRuleFk, Set<ActionState> states);
+
+  /**
+   * Return all the action rules ids which have the required action type and are in the required state
+   *
+   * <p>This is usually "Printer" or "Notify" and "Submitted" state
+   *
+   * @param actionType the action type
+   * @param states the states
+   * @return the distinct
+   */
+  @Query("SELECT DISTINCT a.actionRuleFK FROM Action a WHERE a.actionType =?1 AND a.state IN ?2")
+  List<Integer> findDistinctActionRuleFKByActionTypeAndStateIn(
+      ActionType actionType, Set<ActionDTO.ActionState> states);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/domain/repository/ActionRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/domain/repository/ActionRepository.java
@@ -48,7 +48,8 @@ public interface ActionRepository extends JpaRepository<Action, BigInteger> {
       ActionType actionType, Integer actionRuleFk, Set<ActionState> states);
 
   /**
-   * Return all the action rules ids which have the required action type and are in the required state
+   * Return all the action rules ids which have the required action type and are in the required
+   * state
    *
    * <p>This is usually "Printer" or "Notify" and "Submitted" state
    *

--- a/src/test/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/scheduled/distribution/ActionProcessorTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
@@ -23,6 +24,7 @@ import uk.gov.ons.ctp.response.action.domain.model.Action;
 import uk.gov.ons.ctp.response.action.domain.model.ActionType;
 import uk.gov.ons.ctp.response.action.domain.repository.ActionCaseRepository;
 import uk.gov.ons.ctp.response.action.domain.repository.ActionRepository;
+import uk.gov.ons.ctp.response.action.domain.repository.ActionRuleRepository;
 import uk.gov.ons.ctp.response.action.domain.repository.ActionTypeRepository;
 import uk.gov.ons.ctp.response.action.representation.ActionDTO.ActionEvent;
 import uk.gov.ons.ctp.response.action.representation.ActionDTO.ActionState;
@@ -54,6 +56,8 @@ public class ActionProcessorTest {
 
   @Mock private ActionCaseRepository actionCaseRepo;
 
+  @Mock private ActionRuleRepository actionRuleRepo;
+
   @InjectMocks private ActionProcessor actionProcessor;
 
   /** Initialises Mockito and loads Class Fixtures */
@@ -65,8 +69,12 @@ public class ActionProcessorTest {
     MockitoAnnotations.initMocks(this);
     when(actionTypeRepo.findAll()).thenReturn(actionTypes);
 
+    List<Integer> actionRules = new ArrayList<>();
+    actionRules.add(1);
     for (ActionType actionType : actionTypes) {
-      when(actionRepo.findByActionTypeAndStateIn(eq(actionType), any()))
+      when(actionRepo.findDistinctActionRuleFKByActionTypeAndStateIn(eq(actionType), any()))
+          .thenReturn(actionRules);
+      when(actionRepo.findByActionTypeAndActionRuleFKAndStateIn(eq(actionType), any(), any()))
           .thenReturn(businessEnrolmentActions);
     }
   }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
At the minute Action Service tries to process all actions in submitted state for every action rule in a single transaction. This can often fail, so this change sets splits up each action rule into a separate process and transaction.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
