### PR TITLE
changes to the config to add rabbit queue consuming threads

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,13 @@ name: Build
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
     paths-ignore:
       - _infra/spinnaker/**
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
     paths-ignore:
       - _infra/spinnaker/**
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,13 @@ name: Build
 # events but only for the main branch
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
     paths-ignore:
       - _infra/spinnaker/**
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths-ignore:
       - _infra/spinnaker/**
 

--- a/_infra/helm/action/Chart.yaml
+++ b/_infra/helm/action/Chart.yaml
@@ -18,5 +18,5 @@ version: 1.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.2.13
+appVersion: 12.2.14
 

--- a/_infra/helm/action/templates/deployment.yaml
+++ b/_infra/helm/action/templates/deployment.yaml
@@ -304,5 +304,7 @@ spec:
             value: "$(DB_USERNAME)"
           - name: LIQUIBASE_PASSWORD
             value: "$(DB_PASSWORD)"
+          - name: MESSAGING_CONSUMING_THREADS
+            value: "{{ .Values.messaging.consumingThreads }}"
           resources:
             {{- toYaml .Values.resources.application | nindent 12 }}

--- a/_infra/helm/action/values.yaml
+++ b/_infra/helm/action/values.yaml
@@ -94,4 +94,4 @@ dns:
   wellKnownPort: 8080
 
 messaging:
-  consumingThreads: 100
+  consumingThreads: 10

--- a/_infra/helm/action/values.yaml
+++ b/_infra/helm/action/values.yaml
@@ -94,4 +94,4 @@ dns:
   wellKnownPort: 8080
 
 messaging:
-  consumingThreads: 100
+  consumingThreads: 1000

--- a/_infra/helm/action/values.yaml
+++ b/_infra/helm/action/values.yaml
@@ -93,3 +93,5 @@ dns:
   enabled: false
   wellKnownPort: 8080
 
+messaging:
+  consumingThreads: 100

--- a/_infra/helm/action/values.yaml
+++ b/_infra/helm/action/values.yaml
@@ -94,4 +94,4 @@ dns:
   wellKnownPort: 8080
 
 messaging:
-  consumingThreads: 1000
+  consumingThreads: 100


### PR DESCRIPTION
Rabbit queue is only using a single thread as consuming threads.
Changes to increase the consuming threads in action and making it configurable via deployment.