### PR TITLE
Add reference field to notify emails

### DIFF
--- a/_infra/helm/action/Chart.yaml
+++ b/_infra/helm/action/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.3.28
+version: 12.3.29
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.3.28
+appVersion: 12.3.29
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/NotifyModel.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/NotifyModel.java
@@ -27,6 +27,9 @@ public class NotifyModel {
 
     private Personalisation personalisation;
 
+    @JsonProperty("reference")
+    private String reference;
+
     @Getter
     @Setter
     @Builder
@@ -99,7 +102,8 @@ public class NotifyModel {
         private String region;
         private String surveyRef;
 
-        /* This is lifted directly from the old notify-gateway and comms-template.
+        /*
+         * This is lifted directly from the old notify-gateway and comms-template.
          */
         public Classifiers build() {
           if (NUDGE_EMAIL.equals(actionType)) {

--- a/src/main/java/uk/gov/ons/ctp/response/action/service/ProcessEventService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/service/ProcessEventService.java
@@ -328,6 +328,7 @@ public class ProcessEventService {
     existingEvent.setProcessedTimestamp(Timestamp.from(instant));
     actionEventRepository.save(existingEvent);
   }
+
   /**
    * Populates data for print file for case event
    *
@@ -720,6 +721,7 @@ public class ProcessEventService {
                 .personalisation(personalisation)
                 .classifiers(classifiers)
                 .emailAddress(respondentParty.getAttributes().getEmailAddress())
+                .reference(survey.getSurveyRef() + "-" + businessParty.getAttributes().getRuref())
                 .build());
     log.with("template", actionTemplate.getType())
         .with("case", actionCase.getId())

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/NotifyEmailServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/NotifyEmailServiceTest.java
@@ -66,6 +66,7 @@ public class NotifyEmailServiceTest {
                 .personalisation(personalisation)
                 .classifiers(classifiers)
                 .emailAddress(null)
+                .reference(null)
                 .build()));
 
     Mockito.verify(publisher).sendToPubSub(emailJson);

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/NotifyEmailServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/NotifyEmailServiceTest.java
@@ -38,7 +38,8 @@ public class NotifyEmailServiceTest {
           + "\"return by date\":null,"
           + "\"RU name\":null,"
           + "\"trading style\":null,"
-          + "\"respondent period\":null"
+          + "\"respondent period\":null,"
+          + "\"reference\":null"
           + "}"
           + "}}";
 

--- a/src/test/java/uk/gov/ons/ctp/response/action/service/NotifyEmailServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/service/NotifyEmailServiceTest.java
@@ -38,9 +38,9 @@ public class NotifyEmailServiceTest {
           + "\"return by date\":null,"
           + "\"RU name\":null,"
           + "\"trading style\":null,"
-          + "\"respondent period\":null,"
+          + "\"respondent period\":null"
+          + "},"
           + "\"reference\":null"
-          + "}"
           + "}}";
 
   @Test


### PR DESCRIPTION
# What and why?
This adds the reference field to GovNotify emails so they'll be picked up in reports download from the site

# How to test?

# Trello
https://trello.com/c/e57pqgz3/885-s42-rops-overhaul-provide-additional-details-for-govnotify-reports