### PR TITLE
add new indexes on action.event

### DIFF
--- a/_infra/helm/action/Chart.yaml
+++ b/_infra/helm/action/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.3.34
+version: 12.3.35
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.3.34
+appVersion: 12.3.35
 

--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -90,3 +90,6 @@ databaseChangeLog:
 
 - include:
       file: database/changes/release-29/changelog.yml
+
+- include:
+      file: database/changes/release-30/changelog.yml

--- a/src/main/resources/database/changes/release-30/changelog.yml
+++ b/src/main/resources/database/changes/release-30/changelog.yml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 30-1
+      author: David Morgan
+      changes:
+        - sqlFile:
+            comment: adding indexes to action.events as queries are very slow
+            path: index_action_schema.sql
+            relativeToChangelogFile: true
+            splitStatements: false
+

--- a/src/main/resources/database/changes/release-30/index_action_schema.sql
+++ b/src/main/resources/database/changes/release-30/index_action_schema.sql
@@ -1,31 +1,5 @@
--- ACTION SERVICE
-
-
-
--- action_event table
-
-
--- Index: action_event_case_id_index
-
 CREATE INDEX action_event_case_id_index ON action.action_event USING btree (case_id);
-
-
--- Index: action_event_type_index
-
 CREATE INDEX action_event_type_index ON action.action_event USING btree (type);
-
-
--- Index: action_event_handler_index
-
 CREATE INDEX action_event_handler_index ON action.action_event USING btree (handler);
-
-
--- Index: action_eventevent_tag_index
-
 CREATE INDEX action_event_event_tag_index ON action.action_event USING btree (event_tag);
-
-
--- Index: action_event_status_index
-
 CREATE INDEX action_event_status_index ON action.action_event USING btree (status);
-

--- a/src/main/resources/database/changes/release-30/index_action_schema.sql
+++ b/src/main/resources/database/changes/release-30/index_action_schema.sql
@@ -5,32 +5,27 @@
 -- action_event table
 
 
--- Index: action_eventcase_id_index
--- DROP INDEX action_eventcase_id_index;
+-- Index: action_event_case_id_index
 
 CREATE INDEX action_event_case_id_index ON action.action_event USING btree (case_id);
 
 
--- Index: action_eventtype_index
--- DROP INDEX action_eventtype_index;
+-- Index: action_event_type_index
 
-CREATE INDEX action_eventtype_index ON action.action_event USING btree (type);
+CREATE INDEX action_event_type_index ON action.action_event USING btree (type);
 
 
--- Index: action_eventhandler_index
--- DROP INDEX action_eventhandler_index;
+-- Index: action_event_handler_index
 
-CREATE INDEX action_eventhandler_index ON action.action_event USING btree (handler);
+CREATE INDEX action_event_handler_index ON action.action_event USING btree (handler);
 
 
 -- Index: action_eventevent_tag_index
--- DROP INDEX action_eventevent_tag_index;
 
-CREATE INDEX action_eventevent_tag_index ON action.action_event USING btree (event_tag);
+CREATE INDEX action_event_event_tag_index ON action.action_event USING btree (event_tag);
 
 
--- Index: action_eventstatus_index
--- DROP INDEX action_eventstatus_index;
+-- Index: action_event_status_index
 
-CREATE INDEX action_eventstatus_index ON action.action_event USING btree (status);
+CREATE INDEX action_event_status_index ON action.action_event USING btree (status);
 

--- a/src/main/resources/database/changes/release-30/index_action_schema.sql
+++ b/src/main/resources/database/changes/release-30/index_action_schema.sql
@@ -1,0 +1,36 @@
+-- ACTION SERVICE
+
+
+
+-- action_event table
+
+
+-- Index: action_eventcase_id_index
+-- DROP INDEX action_eventcase_id_index;
+
+CREATE INDEX action_eventcase_id_index ON action.action_event USING btree (case_id);
+
+
+-- Index: action_eventtype_index
+-- DROP INDEX action_eventtype_index;
+
+CREATE INDEX action_eventtype_index ON action.action_event USING btree (type);
+
+
+-- Index: action_eventhandler_index
+-- DROP INDEX action_eventhandler_index;
+
+CREATE INDEX action_eventhandler_index ON action.action_event USING btree (handler);
+
+
+-- Index: action_eventevent_tag_index
+-- DROP INDEX action_eventevent_tag_index;
+
+CREATE INDEX action_eventevent_tag_index ON action.action_event USING btree (event_tag);
+
+
+-- Index: action_eventstatus_index
+-- DROP INDEX action_eventstatus_index;
+
+CREATE INDEX action_eventstatus_index ON action.action_event USING btree (status);
+

--- a/src/main/resources/database/changes/release-30/index_action_schema.sql
+++ b/src/main/resources/database/changes/release-30/index_action_schema.sql
@@ -8,7 +8,7 @@
 -- Index: action_eventcase_id_index
 -- DROP INDEX action_eventcase_id_index;
 
-CREATE INDEX action_eventcase_id_index ON action.action_event USING btree (case_id);
+CREATE INDEX action_event_case_id_index ON action.action_event USING btree (case_id);
 
 
 -- Index: action_eventtype_index


### PR DESCRIPTION
# What and why?
This is a bug fix as the queries are very slow as there are no indexes.
The following jpa method in the isactionable
actionEventRepository.findByCaseIdAndTypeAndHandlerAndTagAndStatus(...)

# How to test?
namespace
# Trello
https://trello.com/c/QWJ1xw00/954-bug-add-index-action-event-table